### PR TITLE
Support descriptions on @throw tags #44

### DIFF
--- a/src/Lib/Operation/ExceptionHandler.php
+++ b/src/Lib/Operation/ExceptionHandler.php
@@ -3,6 +3,7 @@
 namespace SwaggerBake\Lib\Operation;
 
 use Exception;
+use phpDocumentor\Reflection\DocBlock\Tags\Throws;
 
 /**
  * Class ExceptionHandler
@@ -11,13 +12,16 @@ use Exception;
 class ExceptionHandler
 {
     /** @var string  */
-    private $message = 'Unknown Error';
+    private $message;
 
     /** @var string */
     private $code = '500';
 
-    public function __construct(string $exceptionClass)
+    public function __construct(Throws $throw)
     {
+        $exceptionClass = $throw->getType()->__toString();
+        $this->message = trim($throw->getDescription()->getBodyTemplate());
+
         if (substr($exceptionClass, 0 , 1) == '\\') {
             $exceptionClass = substr($exceptionClass, 1);
         }
@@ -58,6 +62,10 @@ class ExceptionHandler
      */
     private function assignMessage($instance) : void
     {
+        if (!empty($this->message)) {
+            return;
+        }
+
         $this->message = trim($instance->getMessage());
         if (!empty($this->message)) {
             return;

--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -119,7 +119,7 @@ class OperationResponse
         $mimeType = reset($mimeTypes);
 
         foreach ($throws as $throw) {
-            $exception = new ExceptionHandler($throw->getType()->__toString());
+            $exception = new ExceptionHandler($throw);
 
             $this->operation->pushResponse(
                 (new Response())

--- a/tests/TestCase/Lib/Operation/ExceptionHandlerTest.php
+++ b/tests/TestCase/Lib/Operation/ExceptionHandlerTest.php
@@ -3,17 +3,33 @@
 namespace SwaggerBake\Test\TestCase\Lib\Operation;
 
 use Cake\TestSuite\TestCase;
+use phpDocumentor\Reflection\DocBlockFactory;
 use SwaggerBake\Lib\Operation\ExceptionHandler;
 
 class ExceptionHandlerTest extends TestCase
 {
-    public function testConstruct()
+    public function testErrorCodes()
     {
-        $this->assertEquals(400, (new ExceptionHandler('BadRequestException'))->getCode());
-        $this->assertEquals(401, (new ExceptionHandler('UnauthorizedException'))->getCode());
-        $this->assertEquals(403, (new ExceptionHandler('ForbiddenException'))->getCode());
-        $this->assertEquals(404, (new ExceptionHandler('RecordNotFoundException'))->getCode());
-        $this->assertEquals(405, (new ExceptionHandler('MethodNotAllowedException'))->getCode());
-        $this->assertEquals(500, (new ExceptionHandler('Exception'))->getCode());
+        $exceptions = [
+            400 => 'BadRequestException',
+            401 => 'UnauthorizedException',
+            403 => 'ForbiddenException',
+            404 => 'RecordNotFoundException',
+            405 => 'MethodNotAllowedException',
+            500 => 'Exception',
+        ];
+
+        $factory = DocBlockFactory::createInstance();
+        foreach ($exceptions as $code => $exception) {
+            $throws = $factory->create("/** @throws $exception */ */")->getTagsByName('throws')[0];
+            $this->assertEquals($code, (new ExceptionHandler($throws))->getCode());
+        }
+    }
+
+    public function testMessage()
+    {
+        $factory = DocBlockFactory::createInstance();
+        $throws = $factory->create("/** @throws Exception description */")->getTagsByName('throws')[0];
+        $this->assertEquals('description', (new ExceptionHandler($throws))->getMessage());
     }
 }


### PR DESCRIPTION
- Set exception description from doc block
- ExceptionHandler constructor was refactored to accept Throws instance
- Modify unit tests and add new one.