### PR TITLE
Handle null FQN from NamespaceUtility::getControllerFullQualifiedNameSpace()

### DIFF
--- a/src/Lib/Path/PathFromRouteFactory.php
+++ b/src/Lib/Path/PathFromRouteFactory.php
@@ -41,7 +41,7 @@ class PathFromRouteFactory
         $controller = $this->route->getController() . 'Controller';
         $fullyQualifiedNamespace = NamespaceUtility::getControllerFullQualifiedNameSpace($controller, $this->config);
 
-        if (!$this->isVisible($fullyQualifiedNamespace)) {
+        if (is_null($fullyQualifiedNamespace) || !$this->isVisible($fullyQualifiedNamespace)) {
             return null;
         }
 


### PR DESCRIPTION
When `$fullyQualifiedNamespace` is null, the `isVisible()` method blows up because it is expecting a string as an argument but null get passed to it. This fix prevents null from being passed into the `isVisible()` method.