### PR TITLE
check if Flash component is loaded in component registry

### DIFF
--- a/src/Controller/Component/SwaggerUiComponent.php
+++ b/src/Controller/Component/SwaggerUiComponent.php
@@ -41,7 +41,7 @@ class SwaggerUiComponent extends Component
 
         foreach ($this->swagger->getOperationsWithNoHttp20x() as $operation) {
             $errorMsg = 'Operation ' . $operation->getOperationId() . ' does not have a HTTP 20x response';
-            if (!isset($this->Flash)) {
+            if (!$this->_registry->has('Flash')) {
                 triggerWarning($errorMsg);
                 continue;
             }


### PR DESCRIPTION
Allows a better check of component is in registry. Since the Flash component is lazily loaded using  

```
public $components = ['Flash'];
```

this `isset($this->Flash)` returns false until the component is first used.