### PR TITLE
XML example cannot be generated; root element name is undefined (#82)

### DIFF
--- a/assets/swagger.yml
+++ b/assets/swagger.yml
@@ -24,8 +24,12 @@ components:
         message:
           type: string
           example: Internal Error
+      xml:
+        name: response
     OperationResult:
       type: object
       properties:
         result:
           type: boolean
+      xml:
+        name: response

--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -17,8 +17,8 @@ class Schema implements JsonSerializable
     /** @var string|null */
     private $title;
 
-    /** @var string|null */
-    private $description;
+    /** @var string */
+    private $description = '';
 
     /** @var string */
     private $type = '';
@@ -50,6 +50,9 @@ class Schema implements JsonSerializable
     /** @var string */
     private $format;
 
+    /** @var Xml|null */
+    private $xml;
+
     /**
      * @return array
      */
@@ -66,8 +69,8 @@ class Schema implements JsonSerializable
         }
 
         // remove empty properties to avoid swagger.json clutter
-        foreach (['title','description','properties','items','oneOf','anyOf','allOf','not','enum','format','type'] as $v) {
-            if (empty($vars[$v]) || is_null($vars[$v])) {
+        foreach (['title','properties','items','oneOf','anyOf','allOf','not','enum','format','type', 'xml'] as $v) {
+            if (array_key_exists($v, $vars) && (empty($vars[$v]) || is_null($vars[$v]))) {
                 unset($vars[$v]);
             }
         }
@@ -213,10 +216,10 @@ class Schema implements JsonSerializable
     }
 
     /**
-     * @param string|null $description
+     * @param string $description
      * @return Schema
      */
-    public function setDescription(?string $description): Schema
+    public function setDescription(string $description): Schema
     {
         $this->description = $description;
         return $this;
@@ -345,6 +348,24 @@ class Schema implements JsonSerializable
     public function setFormat(string $format): Schema
     {
         $this->format = $format;
+        return $this;
+    }
+
+    /**
+     * @return Xml|null
+     */
+    public function getXml(): ?Xml
+    {
+        return $this->xml;
+    }
+
+    /**
+     * @param Xml|null $xml
+     * @return Schema
+     */
+    public function setXml(?Xml $xml): Schema
+    {
+        $this->xml = $xml;
         return $this;
     }
 }

--- a/src/Lib/OpenApi/Xml.php
+++ b/src/Lib/OpenApi/Xml.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace SwaggerBake\Lib\OpenApi;
+
+use JsonSerializable;
+
+/**
+ * Class Xml
+ * @package SwaggerBake\Lib\OpenApi
+ */
+class Xml implements JsonSerializable
+{
+    /** @var string */
+    private $name;
+
+    /** @var string|null */
+    private $namespace;
+
+    /** @var string|null */
+    private $prefix;
+
+    /** @var bool|null */
+    private $attribute;
+
+    /** @var bool|null */
+    private $wrapped;
+
+    /**
+     * @return array
+     */
+    public function toArray() : array
+    {
+        $vars = get_object_vars($this);
+
+        // remove properties if they are set to their defaults (to avoid json clutter)
+        foreach (['attribute','wrapped'] as $v) {
+            if (array_key_exists($v, $vars) && $vars[$v] === false) {
+                unset($vars[$v]);
+            }
+        }
+
+        // remove empty properties to avoid swagger.json clutter
+        foreach (['namespace','prefix','attribute','wrapped'] as $v) {
+            if (array_key_exists($v, $vars) && (is_null($vars[$v]) || empty($vars[$v]))) {
+                unset($vars[$v]);
+            }
+        }
+
+        return $vars;
+    }
+
+    /**
+     * @return array|mixed
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return Xml
+     */
+    public function setName(string $name): Xml
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * @param string|null $namespace
+     * @return Xml
+     */
+    public function setNamespace(?string $namespace): Xml
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPrefix(): ?string
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @param string|null $prefix
+     * @return Xml
+     */
+    public function setPrefix(?string $prefix): Xml
+    {
+        $this->prefix = $prefix;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getAttribute(): ?bool
+    {
+        return $this->attribute;
+    }
+
+    /**
+     * @param bool|null $attribute
+     * @return Xml
+     */
+    public function setAttribute(?bool $attribute): Xml
+    {
+        $this->attribute = $attribute;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getWrapped(): ?bool
+    {
+        return $this->wrapped;
+    }
+
+    /**
+     * @param bool|null $wrapped
+     * @return Xml
+     */
+    public function setWrapped(?bool $wrapped): Xml
+    {
+        $this->wrapped = $wrapped;
+        return $this;
+    }
+}

--- a/src/Lib/Operation/OperationRequestBody.php
+++ b/src/Lib/Operation/OperationRequestBody.php
@@ -17,6 +17,7 @@ use SwaggerBake\Lib\OpenApi\Operation;
 use SwaggerBake\Lib\OpenApi\RequestBody;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
+use SwaggerBake\Lib\OpenApi\Xml;
 use SwaggerBake\Lib\Utility\DocBlockUtility;
 
 /**
@@ -249,6 +250,12 @@ class OperationRequestBody
                     $schemaProperty->setRequired(true);
                 }
                 $schema->pushProperty($schemaProperty);
+            }
+
+            if ($mimeType == 'application/xml') {
+                $schema->setXml(
+                    (new Xml())->setName(strtolower($this->schema->getName()))
+                );
             }
 
             $requestBody->pushContent(

--- a/src/Lib/Schema/SchemaFromYamlFactory.php
+++ b/src/Lib/Schema/SchemaFromYamlFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SwaggerBake\Lib\Schema;
+
+use SwaggerBake\Lib\OpenApi\Schema;
+use SwaggerBake\Lib\OpenApi\Xml;
+
+/**
+ * Class SchemaFromYamlFactory
+ * @package SwaggerBake\Lib\Schema
+ */
+class SchemaFromYamlFactory
+{
+    /**
+     * Create an instance of Schema from YAML
+     *
+     * @param string $name
+     * @param array $yml
+     * @return Schema
+     */
+    public function create(string $name, array $yml) : Schema
+    {
+        $schema = (new Schema())
+            ->setName($name)
+            ->setTitle($yml['title'] ?? '')
+            ->setType($yml['type'] ?? '')
+            ->setDescription($yml['description'] ?? '')
+            ->setItems($yml['items'] ?? [])
+            ->setAllOf($yml['allOf'] ?? [])
+            ->setAnyOf($yml['anyOf'] ?? [])
+            ->setOneOf($yml['oneOf'] ?? [])
+            ->setNot($yml['oneOf'] ?? [])
+        ;
+
+        if (isset($yml['xml'])) {
+            $schema->setXml(
+                (new Xml())
+                    ->setName($yml['xml']['name'])
+                    ->setAttribute($yml['xml']['attribute'] ?? null)
+                    ->setNamespace($yml['xml']['namespace'] ?? null)
+                    ->setPrefix($yml['xml']['prefix'] ?? null)
+                    ->setWrapped($yml['xml']['wrapped'] ?? null)
+            );
+        }
+
+        $factory = new SchemaPropertyFromYamlFactory();
+        $yml['properties'] = $yml['properties'] ?? [];
+
+        foreach ($yml['properties'] as $propertyName => $propertyVar) {
+            $schema->pushProperty(
+                $factory->create($propertyName, $propertyVar)
+            );
+        }
+
+        return $schema;
+    }
+}

--- a/src/Lib/Schema/SchemaPropertyFromYamlFactory.php
+++ b/src/Lib/Schema/SchemaPropertyFromYamlFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SwaggerBake\Lib\Schema;
+
+use SwaggerBake\Lib\OpenApi\SchemaProperty;
+
+/**
+ * Class SchemaPropertyFromYamlFactory
+ * @package SwaggerBake\Lib\Schema
+ */
+class SchemaPropertyFromYamlFactory
+{
+    /**
+     * Creates an instance of SchemaProperty from YAML
+     *
+     * @param string $name
+     * @param array $yaml
+     * @return SchemaProperty
+     */
+    public function create(string $name, array $yaml) : SchemaProperty
+    {
+        $schemaProperty = (new SchemaProperty())
+            ->setName($name)
+            ->setDescription($yaml['description'] ?? '')
+            ->setType($yaml['type'] ?? '')
+            ->setReadOnly($yaml['readonly'] ?? false)
+            ->setWriteOnly($yaml['writeOnly'] ?? false)
+            ->setRequired($yaml['required'] ?? false)
+            ->setEnum($yaml['enum'] ?? [])
+            ->setExample($yaml['example'] ?? '')
+        ;
+
+        $properties = [
+            'maxLength',
+            'minLength',
+            'pattern',
+            'maxItems',
+            'minItems',
+            'uniqueItems',
+            'maxProperties',
+            'exclusiveMaximum',
+            'exclusiveMinimum',
+            'uniqueItems',
+            'maxProperties',
+            'minProperties',
+        ];
+
+        foreach ($properties as $property) {
+            if (!isset($yaml[$property])) {
+                continue;
+            }
+            $setterMethod = 'set' . ucfirst($property);
+            $schemaProperty->{$setterMethod}($yaml[$property]);
+        }
+
+        return $schemaProperty;
+    }
+}

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -12,6 +12,7 @@ use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
 use SwaggerBake\Lib\Operation\OperationFromRouteFactory;
 use SwaggerBake\Lib\Path\PathFromRouteFactory;
+use SwaggerBake\Lib\Schema\SchemaFromYamlFactory;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -322,31 +323,10 @@ class Swagger
             $array['components']['schemas'] = [];
         }
 
+        $factory = new SchemaFromYamlFactory();
+
         foreach ($array['components']['schemas'] as $schemaName => $schemaVar) {
-
-            $schema = (new Schema())
-                ->setName($schemaName)
-                ->setType($schemaVar['type'] ?? '')
-                ->setDescription($schemaVar['description'] ?? '')
-                ->setItems($schemaVar['items'] ?? [])
-                ->setAllOf($schemaVar['allOf'] ?? [])
-                ->setAnyOf($schemaVar['anyOf'] ?? [])
-                ->setOneOf($schemaVar['oneOf'] ?? [])
-            ;
-
-            $schemaVar['properties'] = $schemaVar['properties'] ?? [];
-
-            foreach ($schemaVar['properties'] as $propertyName => $propertyVar) {
-                $property = (new SchemaProperty())
-                    ->setType($propertyVar['type'])
-                    ->setName($propertyName)
-                    ->setFormat($propertyVar['type'] ?? '')
-                    ->setExample($propertyVar['example'] ?? '')
-                ;
-                $schema->pushProperty($property);
-            }
-
-            $array['components']['schemas'][$schemaName] = $schema;
+            $array['components']['schemas'][$schemaName] = $factory->create($schemaName, $schemaVar);
         }
 
         return $array;
@@ -413,6 +393,9 @@ class Swagger
         return isset($this->array['paths'][$resource]);
     }
 
+    /**
+     * @return string
+     */
     public function __toString(): string
     {
         return $this->toString();

--- a/tests/test_app/config/swagger-with-existing.yml
+++ b/tests/test_app/config/swagger-with-existing.yml
@@ -160,7 +160,11 @@ components:
         code:
           type: integer
           format: int32
+          example: 400
         message:
           type: string
+          example: error message here
+      xml:
+        name: response
 security:
   - BearerAuth: []


### PR DESCRIPTION
- Added new OpenApi/Xml class
- Updated assets to include xml->name = response
- Updated unit tests
- Added OpenApi/Schema::xml
- Update OperationRequestBody and OperationResponse to use new Xml class
- Created Yaml Schema and SchemaProperty factories which includes Xml
and other properties that were missed