### PR TITLE
Set SchemaProperty::format from Cake Validator rules (#88)

### DIFF
--- a/src/Lib/Decorator/EntityDecorator.php
+++ b/src/Lib/Decorator/EntityDecorator.php
@@ -5,8 +5,6 @@ namespace SwaggerBake\Lib\Decorator;
 
 use Cake\ORM\Entity;
 use ReflectionClass;
-use ReflectionException;
-use SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException;
 
 /**
  * Class EntityDecorator

--- a/src/Lib/Schema/SchemaPropertyFactory.php
+++ b/src/Lib/Schema/SchemaPropertyFactory.php
@@ -45,7 +45,13 @@ class SchemaPropertyFactory
             ->setFormat(DataTypeConversion::toFormat($property->getType()))
             ->setReadOnly($this->isReadOnly($property));
 
-        return (new SchemaPropertyValidation($this->validator, $schemaProperty, $property))->withValidations();
+        $schemaProperty = (new SchemaPropertyValidation($this->validator, $schemaProperty, $property))
+            ->withValidations();
+
+        $schemaProperty = (new SchemaPropertyFormat($this->validator, $schemaProperty, $property))
+            ->withFormat();
+
+        return $schemaProperty;
     }
 
     /**

--- a/src/Lib/Schema/SchemaPropertyFormat.php
+++ b/src/Lib/Schema/SchemaPropertyFormat.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+namespace SwaggerBake\Lib\Schema;
+
+use Cake\Validation\ValidationRule;
+use Cake\Validation\Validator;
+use SwaggerBake\Lib\Decorator\PropertyDecorator;
+use SwaggerBake\Lib\OpenApi\SchemaProperty;
+
+/**
+ * Assigns SchemaProperty::format using CakePHP Validator
+ *
+ * @package SwaggerBake\Lib\Schema
+ */
+class SchemaPropertyFormat
+{
+    /**
+     * @var array CakePHP validation rule => SchemaProperty::Format
+     */
+    private const MAPPINGS = [
+        'creditCard' => 'credit-card',
+        'date' => 'date',
+        'dateTime' => 'date-time',
+        'email' => 'email',
+        'ipv4' => 'ipv4',
+        'ipv6' => 'ipv6',
+        'latitude' => 'latitude',
+        'longitude' => 'longitude',
+        'time' => 'time',
+        'url' => 'url',
+        'urlWithProtocol' => 'url',
+        'uuid' => 'uuid',
+    ];
+
+    /**
+     * @var \Cake\Validation\Validator
+     */
+    private $validator;
+
+    /**
+     * @var \SwaggerBake\Lib\OpenApi\SchemaProperty
+     */
+    private $schemaProperty;
+
+    /**
+     * @var string
+     */
+    private $propertyName;
+
+    /**
+     * @param \Cake\Validation\Validator $validator Validator
+     * @param \SwaggerBake\Lib\OpenApi\SchemaProperty $schemaProperty SchemaProperty
+     * @param \SwaggerBake\Lib\Decorator\PropertyDecorator $propertyDecorator PropertyDecorator
+     */
+    public function __construct(
+        Validator $validator,
+        SchemaProperty $schemaProperty,
+        PropertyDecorator $propertyDecorator
+    ) {
+        $this->validator = $validator;
+        $this->schemaProperty = $schemaProperty;
+        $this->propertyName = $propertyDecorator->getName();
+    }
+
+    /**
+     * Sets SchemaProperty::format using CakePHP validator settings and returns SchemaProperty
+     *
+     * @return \SwaggerBake\Lib\OpenApi\SchemaProperty
+     */
+    public function withFormat(): SchemaProperty
+    {
+        if (!empty($this->schemaProperty->getFormat())) {
+            return $this->schemaProperty;
+        }
+
+        foreach (self::MAPPINGS as $rule => $format) {
+            if ($this->hasValidationRuleValue($rule)) {
+                $this->schemaProperty->setFormat($format);
+            }
+        }
+
+        return $this->schemaProperty;
+    }
+
+    /**
+     * Checks if a rule exists
+     *
+     * @param string $rule Rule name
+     * @return bool
+     */
+    private function hasValidationRuleValue(string $rule): bool
+    {
+        $validationRule = $this->validator->field($this->propertyName)->rule($rule);
+
+        if (!$validationRule instanceof ValidationRule) {
+            return false;
+        }
+
+        if (!empty($validationRule->get('on'))) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Lib/Schema/SchemaPropertyValidation.php
+++ b/src/Lib/Schema/SchemaPropertyValidation.php
@@ -10,11 +10,9 @@ use SwaggerBake\Lib\Decorator\PropertyDecorator;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
 
 /**
- * Class SchemaPropertyValidation
+ * Checks validation rules in your projects Table classes and set Schema Properties from them
  *
  * @package SwaggerBake\Lib\Schema
- *
- * Checks validation rules in your projects Table classes and set Schema Properties from them
  */
 class SchemaPropertyValidation
 {

--- a/src/Lib/Utility/NamespaceUtility.php
+++ b/src/Lib/Utility/NamespaceUtility.php
@@ -7,7 +7,6 @@ use LogicException;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException;
 
-
 /**
  * Class NamespaceUtility
  *
@@ -21,13 +20,13 @@ class NamespaceUtility
      * @param string $className Controller name
      * @param \SwaggerBake\Lib\Configuration $config Configuration
      * @return string|null
-     * @throws SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
+     * @throws \SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
      */
     public static function getControllerFullQualifiedNameSpace(string $className, Configuration $config): ?string
     {
         try {
             $namespaces = $config->getNamespaces();
-        } catch(LogicException $e) {
+        } catch (LogicException $e) {
             throw new SwaggerBakeRunTimeException(
                 'Invalid configuration, missing SwaggerBake.namespaces.controllers'
             );
@@ -49,13 +48,13 @@ class NamespaceUtility
      * @param string $className Entity class name
      * @param \SwaggerBake\Lib\Configuration $config Configuration
      * @return string|null
-     * @throws SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
+     * @throws \SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
      */
     public static function getEntityFullyQualifiedNameSpace(string $className, Configuration $config): ?string
     {
         try {
             $namespaces = $config->getNamespaces();
-        } catch(LogicException $e) {
+        } catch (LogicException $e) {
             throw new SwaggerBakeRunTimeException(
                 'Invalid configuration, missing SwaggerBake.namespaces.entities'
             );
@@ -77,13 +76,13 @@ class NamespaceUtility
      * @param string $className Table class name
      * @param \SwaggerBake\Lib\Configuration $config Configuration
      * @return string|null
-     * @throws SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
+     * @throws \SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
      */
     public static function getTableFullyQualifiedNameSpace(string $className, Configuration $config): ?string
     {
         try {
             $namespaces = $config->getNamespaces();
-        } catch(LogicException $e) {
+        } catch (LogicException $e) {
             throw new SwaggerBakeRunTimeException(
                 'Invalid configuration, missing SwaggerBake.namespaces.tables'
             );

--- a/tests/TestCase/Lib/Schema/SchemaPropertyFormatTest.php
+++ b/tests/TestCase/Lib/Schema/SchemaPropertyFormatTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SwaggerBake\Test\TestCase\Lib;
+
+use Cake\TestSuite\TestCase;
+use Cake\Validation\Validator;
+use SwaggerBake\Lib\Decorator\PropertyDecorator;
+use SwaggerBake\Lib\OpenApi\SchemaProperty;
+use SwaggerBake\Lib\Schema\SchemaPropertyFactory;
+use SwaggerBake\Lib\Schema\SchemaPropertyFormat;
+use SwaggerBake\Lib\Utility\DataTypeConversion;
+
+class SchemaPropertyFormatTest extends TestCase
+{
+    public function testWithFormat()
+    {
+        // cakephp validator rule => scalar data type
+        $rules = [
+            'creditCard' => ['type' => 'string', 'format' => 'credit-card'],
+            'date'  => ['type' => 'string', 'format' => 'date'],
+            'dateTime' => ['type' => 'string', 'format' => 'date-time'],
+            'email' => ['type' => 'string', 'format' => 'email'],
+            'ipv4' => ['type' => 'string', 'format' => 'ipv4'],
+            'ipv6' => ['type' => 'string', 'format' => 'ipv6'],
+            'latitude' => ['type' => 'float', 'format' => 'latitude'],
+            'longitude' => ['type' => 'float', 'format' => 'longitude'],
+            'time' => ['type' => 'string', 'format' => 'time'],
+            'url' => ['type' => 'string', 'format' => 'url'],
+            'urlWithProtocol' => ['type'=>'string', 'format' => 'url'],
+            'uuid' => ['type' => 'string', 'format' => 'uuid'],
+        ];
+
+        foreach ($rules as $rule => $vars) {
+
+            $schemaPropertyFormat = new SchemaPropertyFormat(
+                (new Validator())->{$rule}('test_field'),
+                (new SchemaProperty())->setName('test_field')->setType($vars['type']),
+                (new PropertyDecorator())->setName('test_field')->setType($vars['type'])
+            );
+            $schemaProperty = $schemaPropertyFormat->withFormat();
+            $this->assertEquals(
+                $vars['format'],
+                $schemaProperty->getFormat(),
+                'Failed checking for format `' . $vars['format'] . '` from rule `' . $rule . '`'
+            );
+        }
+    }
+}

--- a/tests/TestCase/Lib/Schema/SchemaPropertyValidationTest.php
+++ b/tests/TestCase/Lib/Schema/SchemaPropertyValidationTest.php
@@ -5,7 +5,9 @@ namespace SwaggerBake\Test\TestCase\Lib;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use SwaggerBake\Lib\Decorator\PropertyDecorator;
+use SwaggerBake\Lib\OpenApi\SchemaProperty;
 use SwaggerBake\Lib\Schema\SchemaPropertyFactory;
+use SwaggerBake\Lib\Schema\SchemaPropertyFormat;
 use SwaggerBake\Lib\Schema\SchemaPropertyValidation;
 
 class SchemaPropertyValidationTest extends TestCase
@@ -19,13 +21,10 @@ class SchemaPropertyValidationTest extends TestCase
             ->maxLength('test_field',10)
         ;
 
-        $propertyDecorator = (new PropertyDecorator())->setName('test_field')->setType('integer');
-        $schemaProperty = (new SchemaPropertyFactory($validator))->create($propertyDecorator);
-
         $schemaPropertyValidation = new SchemaPropertyValidation(
             $validator,
-            $schemaProperty,
-            $propertyDecorator
+            (new SchemaProperty())->setName('test_field')->setType('integer'),
+            (new PropertyDecorator())->setName('test_field')->setType('integer')
         );
 
         $schemaProperty = $schemaPropertyValidation->withValidations();
@@ -44,13 +43,10 @@ class SchemaPropertyValidationTest extends TestCase
             ->greaterThanOrEqual('test_field', 1)
             ->lessThanOrEqual('test_field', 1000);
 
-        $propertyDecorator = (new PropertyDecorator())->setName('test_field')->setType('integer');
-        $schemaProperty = (new SchemaPropertyFactory($validator))->create($propertyDecorator);
-
         $schemaPropertyValidation = new SchemaPropertyValidation(
             $validator,
-            $schemaProperty,
-            $propertyDecorator
+            (new SchemaProperty())->setName('test_field')->setType('integer'),
+            (new PropertyDecorator())->setName('test_field')->setType('integer')
         );
 
         $schemaProperty = $schemaPropertyValidation->withValidations();
@@ -65,13 +61,10 @@ class SchemaPropertyValidationTest extends TestCase
             ->greaterThan('test_field', 1)
             ->lessThan('test_field', 1000);
 
-        $propertyDecorator = (new PropertyDecorator())->setName('test_field')->setType('integer');
-        $schemaProperty = (new SchemaPropertyFactory($validator))->create($propertyDecorator);
-
         $schemaPropertyValidation = new SchemaPropertyValidation(
             $validator,
-            $schemaProperty,
-            $propertyDecorator
+            (new SchemaProperty())->setName('test_field')->setType('integer'),
+            (new PropertyDecorator())->setName('test_field')->setType('integer')
         );
 
         $schemaProperty = $schemaPropertyValidation->withValidations();
@@ -89,13 +82,10 @@ class SchemaPropertyValidationTest extends TestCase
             ->hasAtLeast('test_field', 2)
             ->hasAtMost('test_field', 4);
 
-        $propertyDecorator = (new PropertyDecorator())->setName('test_field');
-        $schemaProperty = (new SchemaPropertyFactory($validator))->create($propertyDecorator);
-
         $schemaPropertyValidation = new SchemaPropertyValidation(
             $validator,
-            $schemaProperty,
-            $propertyDecorator
+            (new SchemaProperty())->setName('test_field'),
+            (new PropertyDecorator())->setName('test_field')
         );
 
         $schemaProperty = $schemaPropertyValidation->withValidations();
@@ -110,13 +100,10 @@ class SchemaPropertyValidationTest extends TestCase
         $validator = (new Validator())
             ->requirePresence('test_field', 'create');
 
-        $propertyDecorator = (new PropertyDecorator())->setName('test_field');
-        $schemaProperty = (new SchemaPropertyFactory($validator))->create($propertyDecorator);
-
         $schemaPropertyValidation = new SchemaPropertyValidation(
             $validator,
-            $schemaProperty,
-            $propertyDecorator
+            (new SchemaProperty())->setName('test_field'),
+            (new PropertyDecorator())->setName('test_field')
         );
 
         $schemaProperty = $schemaPropertyValidation->withValidations();
@@ -131,13 +118,10 @@ class SchemaPropertyValidationTest extends TestCase
         $validator = (new Validator())
             ->requirePresence('test_field', 'update');
 
-        $propertyDecorator = (new PropertyDecorator())->setName('test_field');
-        $schemaProperty = (new SchemaPropertyFactory($validator))->create($propertyDecorator);
-
         $schemaPropertyValidation = new SchemaPropertyValidation(
             $validator,
-            $schemaProperty,
-            $propertyDecorator
+            (new SchemaProperty())->setName('test_field'),
+            (new PropertyDecorator())->setName('test_field')
         );
 
         $schemaProperty = $schemaPropertyValidation->withValidations();
@@ -155,13 +139,10 @@ class SchemaPropertyValidationTest extends TestCase
         ];
 
         foreach ($validators as $rule => $validator) {
-            $propertyDecorator = (new PropertyDecorator())->setName('test_field')->setType('string');
-            $schemaProperty = (new SchemaPropertyFactory($validator))->create($propertyDecorator);
-
             $schemaPropertyValidation = new SchemaPropertyValidation(
                 $validator,
-                $schemaProperty,
-                $propertyDecorator
+                (new SchemaProperty())->setName('test_field')->setType('string'),
+                (new PropertyDecorator())->setName('test_field')->setType('string')
             );
 
             $schemaProperty = $schemaPropertyValidation->withValidations();


### PR DESCRIPTION
- Added SchemaPropertyFormat class
- Call new class from SchemaPropertyFactory
- Added unit tests
- Refactored unit tests for SchemaPropertyValidation to reduce lines
of code and improve speed
- Fixed some items found by phpcs