### PR TITLE
Adds support for Validator::lengthBetween(), plus phpcs fixes (#89)

### DIFF
--- a/src/Lib/Decorator/EntityDecorator.php
+++ b/src/Lib/Decorator/EntityDecorator.php
@@ -5,8 +5,6 @@ namespace SwaggerBake\Lib\Decorator;
 
 use Cake\ORM\Entity;
 use ReflectionClass;
-use ReflectionException;
-use SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException;
 
 /**
  * Class EntityDecorator

--- a/src/Lib/Schema/SchemaPropertyValidation.php
+++ b/src/Lib/Schema/SchemaPropertyValidation.php
@@ -78,6 +78,7 @@ class SchemaPropertyValidation
      *
      * @param string $rule Rule name
      * @return array|mixed|null
+     * @codeCoverageIgnore
      */
     private function getValidationRuleValue(string $rule)
     {
@@ -105,6 +106,7 @@ class SchemaPropertyValidation
      *
      * @param string $rule Rule name
      * @return mixed
+     * @codeCoverageIgnore
      */
     private function getValidationRuleValueFromClosure(string $rule)
     {
@@ -136,6 +138,15 @@ class SchemaPropertyValidation
         $result = $this->getValidationRuleValue('maxLength');
         if (!empty($result)) {
             $this->schemaProperty->setMaxLength(intval(reset($result)));
+
+            return $this;
+        }
+
+        $result = $this->getValidationRuleValue('lengthBetween');
+        if (!empty($result)) {
+            $this->schemaProperty->setMaxLength(intval(end($result)));
+
+            return $this;
         }
 
         return $this;
@@ -175,6 +186,15 @@ class SchemaPropertyValidation
         $result = $this->getValidationRuleValue('minLength');
         if (!empty($result)) {
             $this->schemaProperty->setMinLength(intval(reset($result)));
+
+            return $this;
+        }
+
+        $result = $this->getValidationRuleValue('lengthBetween');
+        if (!empty($result)) {
+            $this->schemaProperty->setMinLength(intval(reset($result)));
+
+            return $this;
         }
 
         return $this;
@@ -271,11 +291,9 @@ class SchemaPropertyValidation
 
         $items = reset($result);
 
-        if (empty($items)) {
-            return $this;
+        if (!empty($items)) {
+            $this->schemaProperty->setEnum($items);
         }
-
-        $this->schemaProperty->setEnum($items);
 
         return $this;
     }

--- a/src/Lib/Utility/NamespaceUtility.php
+++ b/src/Lib/Utility/NamespaceUtility.php
@@ -7,7 +7,6 @@ use LogicException;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException;
 
-
 /**
  * Class NamespaceUtility
  *
@@ -21,13 +20,13 @@ class NamespaceUtility
      * @param string $className Controller name
      * @param \SwaggerBake\Lib\Configuration $config Configuration
      * @return string|null
-     * @throws SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
+     * @throws \SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
      */
     public static function getControllerFullQualifiedNameSpace(string $className, Configuration $config): ?string
     {
         try {
             $namespaces = $config->getNamespaces();
-        } catch(LogicException $e) {
+        } catch (LogicException $e) {
             throw new SwaggerBakeRunTimeException(
                 'Invalid configuration, missing SwaggerBake.namespaces.controllers'
             );
@@ -49,13 +48,13 @@ class NamespaceUtility
      * @param string $className Entity class name
      * @param \SwaggerBake\Lib\Configuration $config Configuration
      * @return string|null
-     * @throws SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
+     * @throws \SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
      */
     public static function getEntityFullyQualifiedNameSpace(string $className, Configuration $config): ?string
     {
         try {
             $namespaces = $config->getNamespaces();
-        } catch(LogicException $e) {
+        } catch (LogicException $e) {
             throw new SwaggerBakeRunTimeException(
                 'Invalid configuration, missing SwaggerBake.namespaces.entities'
             );
@@ -77,13 +76,13 @@ class NamespaceUtility
      * @param string $className Table class name
      * @param \SwaggerBake\Lib\Configuration $config Configuration
      * @return string|null
-     * @throws SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
+     * @throws \SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
      */
     public static function getTableFullyQualifiedNameSpace(string $className, Configuration $config): ?string
     {
         try {
             $namespaces = $config->getNamespaces();
-        } catch(LogicException $e) {
+        } catch (LogicException $e) {
             throw new SwaggerBakeRunTimeException(
                 'Invalid configuration, missing SwaggerBake.namespaces.tables'
             );

--- a/tests/TestCase/Lib/Schema/SchemaPropertyValidationTest.php
+++ b/tests/TestCase/Lib/Schema/SchemaPropertyValidationTest.php
@@ -12,6 +12,7 @@ class SchemaPropertyValidationTest extends TestCase
 {
     public function testWithValidations()
     {
+        // min/max length, regex, and required
         $validator = (new Validator())
             ->requirePresence('test_field', true)
             ->regex('test_field', '/\D/')
@@ -34,6 +35,23 @@ class SchemaPropertyValidationTest extends TestCase
         $this->assertFalse($schemaProperty->isRequirePresenceOnCreate());
         $this->assertFalse($schemaProperty->isRequirePresenceOnUpdate());
         $this->assertEquals('/\D/', $schemaProperty->getPattern());
+        $this->assertEquals(5, $schemaProperty->getMinLength());
+        $this->assertEquals(10, $schemaProperty->getMaxLength());
+
+        // length between
+        $validator = (new Validator())->lengthBetween('test_field', [5,10]);
+
+        $propertyDecorator = (new PropertyDecorator())->setName('test_field')->setType('integer');
+        $schemaProperty = (new SchemaPropertyFactory($validator))->create($propertyDecorator);
+
+        $schemaPropertyValidation = new SchemaPropertyValidation(
+            $validator,
+            $schemaProperty,
+            $propertyDecorator
+        );
+
+        $schemaProperty = $schemaPropertyValidation->withValidations();
+
         $this->assertEquals(5, $schemaProperty->getMinLength());
         $this->assertEquals(10, $schemaProperty->getMaxLength());
     }


### PR DESCRIPTION
This is actually for #87 

- SchemaPropertyValidator and tests:
- - Translate Validator::lengthBetween to minLength and maxLenth
- - Instructed phpunit coverage to ignore methods which are clearly
covered by multiple tests
- - Some light refactoring
- PHPCS fixes to EntityDecorator and NamespaceUtility