### PR TITLE
Fixes warning during install and other bugs found during regression #117

### DIFF
--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -6,6 +6,7 @@ namespace SwaggerBake\Command;
 use Cake\Console\Arguments;
 use Cake\Console\Command;
 use Cake\Console\ConsoleIo;
+use Cake\Core\Configure;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\Factory\SwaggerFactory;
 use SwaggerBake\Lib\Utility\ValidateConfiguration;
@@ -16,6 +17,8 @@ use SwaggerBake\Lib\Utility\ValidateConfiguration;
  */
 class BakeCommand extends Command
 {
+    use CommandTrait;
+
     /**
      * Writes a swagger.json file
      *
@@ -25,6 +28,8 @@ class BakeCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
+        $this->loadConfig();
+
         $io->out("Running...");
 
         $config = new Configuration();

--- a/src/Command/CommandTrait.php
+++ b/src/Command/CommandTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SwaggerBake\Command;
+
+use Cake\Core\Configure;
+use SwaggerBake\Lib\AnnotationLoader;
+use SwaggerBake\Lib\ExtensionLoader;
+use SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException;
+
+trait CommandTrait
+{
+    /**
+     * Loads configuration
+     *
+     * @return void
+     * @throws SwaggerBakeRunTimeException
+     */
+    public function loadConfig(): void
+    {
+        if (!file_exists(CONFIG . 'swagger_bake.php')) {
+            throw new SwaggerBakeRunTimeException(
+                'SwaggerBake configuration file `config/swagger_bake.php` is missing'
+            );
+        }
+
+        Configure::load('swagger_bake', 'default');
+        AnnotationLoader::load();
+        ExtensionLoader::load();
+    }
+}

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -50,6 +50,15 @@ class InstallCommand extends Command
             }
         }
 
+        do {
+            $path = $io->ask('What is your relative API path (e.g. /api)');
+            if (empty($path) || !filter_var('http://localhost' . $path, FILTER_VALIDATE_URL)) {
+                $io->warning('You must enter a valid API path');
+                unset($path);
+            }
+        }
+        while (!isset($path));
+
         if (!copy("$assets/swagger.yml", CONFIG . 'swagger.yml')) {
             $io->error('Unable to copy swagger.yml, check permissions');
             return;
@@ -60,16 +69,13 @@ class InstallCommand extends Command
             return;
         }
 
-        $path = $io->ask('What is your relative API path (e.g. /api)');
-        if (!empty($path)) {
-            $contents = file_get_contents(CONFIG . 'swagger.yml');
-            $contents = str_replace('YOUR-SERVER-HERE', $path, $contents);
-            file_put_contents(CONFIG . 'swagger.yml', $contents);
+        $contents = file_get_contents(CONFIG . 'swagger.yml');
+        $contents = str_replace('YOUR-SERVER-HERE', $path, $contents);
+        file_put_contents(CONFIG . 'swagger.yml', $contents);
 
-            $contents = file_get_contents(CONFIG . 'swagger_bake.php');
-            $contents = str_replace('/your-relative-api-url', $path, $contents);
-            file_put_contents(CONFIG . 'swagger_bake.php', $contents);
-        }
+        $contents = file_get_contents(CONFIG . 'swagger_bake.php');
+        $contents = str_replace('/your-relative-api-url', $path, $contents);
+        file_put_contents(CONFIG . 'swagger_bake.php', $contents);
 
         $io->success('Installation Complete!');
 

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -20,6 +20,8 @@ use SwaggerBake\Lib\Utility\ValidateConfiguration;
  */
 class ModelCommand extends Command
 {
+    use CommandTrait;
+
     /**
      * List Cake Entities that can be added to Swagger. Prints to console.
      *
@@ -29,6 +31,8 @@ class ModelCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
+        $this->loadConfig();
+
         $io->hr();
         $io->out("| SwaggerBake is checking your models...");
         $io->hr();

--- a/src/Command/RouteCommand.php
+++ b/src/Command/RouteCommand.php
@@ -20,6 +20,8 @@ use SwaggerBake\Lib\Utility\ValidateConfiguration;
  */
 class RouteCommand extends Command
 {
+    use CommandTrait;
+
     /**
      * List Cake Routes that can be added to Swagger. Prints to console.
      *
@@ -29,6 +31,8 @@ class RouteCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
+        $this->loadConfig();
+
         $io->hr();
         $io->out("| SwaggerBake is checking your routes...");
         $io->hr();

--- a/src/Lib/Operation/OperationSecurity.php
+++ b/src/Lib/Operation/OperationSecurity.php
@@ -94,7 +94,7 @@ class OperationSecurity
         }
 
         $array = $this->swagger->getArray();
-        if (count($array['components']['securitySchemes']) !== 1) {
+        if (!isset($array['components']['securitySchemes']) || count($array['components']['securitySchemes']) !== 1) {
             return;
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,14 +19,16 @@ class Plugin extends BasePlugin
 {
     public function bootstrap(PluginApplicationInterface $app) : void
     {
-        parent::bootstrap($app);
-        if (!file_exists(CONFIG . 'swagger_bake.php')) {
-            triggerWarning('Missing configuration file for config/swagger_bake.php');
+        if (file_exists(CONFIG . 'swagger_bake.php')) {
+            Configure::load('swagger_bake', 'default');
+            AnnotationLoader::load();
+            ExtensionLoader::load();
             return;
         }
-        Configure::load('swagger_bake', 'default');
-        AnnotationLoader::load();
-        ExtensionLoader::load();
+
+        if (PHP_SAPI !== 'cli') {
+            triggerWarning('SwaggerBake configuration file `config/swagger_bake.php` is missing');
+        }
     }
 
     public function console(CommandCollection $commands): CommandCollection


### PR DESCRIPTION
Fixes the warning noted in the bug report and a warning message from OperationSecurity if a securitySchema is not defined in swagger.yml

- Config file is no longer loaded in Plugin->bootstrap() if being run through the CLI
- For CLI the config is now load via CommandTrait->loadConfig()
- `bin/cake swagger install` does not load the config any longer
- Prevent warning in OperationSecurity->assignAuthenticationComponent() with isset() check.
- Made some improvements to order of operations with the installer