### PR TITLE
Do not display Array of Objects in OpenApi Schema #119

### DIFF
--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -180,7 +180,7 @@ class OperationResponse
         if ($action === 'index') {
             $schema = (new Schema())
                 ->setType('array')
-                ->setItems(['$ref' => '#/components/schemas/' . Inflector::pluralize($this->schema->getName())]);
+                ->setItems(['$ref' => '#/components/schemas/' . $this->schema->getName()]);
         }
 
         $response = (new Response())->setCode('200');

--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Lib\Operation;
 
-use Cake\Utility\Inflector;
 use phpDocumentor\Reflection\DocBlock;
 use SwaggerBake\Lib\Annotation\SwagResponseSchema;
 use SwaggerBake\Lib\Configuration;

--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -167,11 +167,7 @@ class OperationResponse
      */
     private function assignSchema(): void
     {
-        if (!$this->schema) {
-            return;
-        }
-
-        if ($this->operation->hasSuccessResponseCode()) {
+        if (!$this->schema || $this->operation->hasSuccessResponseCode()) {
             return;
         }
 
@@ -181,43 +177,25 @@ class OperationResponse
 
         $schema = clone $this->schema;
 
-        if (in_array(strtolower($this->route->getAction()), ['index'])) {
-            $response = (new Response())->setCode('200');
+        $response = (new Response())->setCode('200');
 
-            foreach ($this->config->getResponseContentTypes() as $mimeType) {
-                if ($mimeType == 'application/xml') {
-                    $schema->setXml((new Xml())->setName('response'));
-                }
-
-                $response->pushContent(
-                    (new Content())
-                        ->setSchema($schema)
-                        ->setMimeType($mimeType)
+        foreach ($this->config->getResponseContentTypes() as $mimeType) {
+            if ($mimeType == 'application/xml') {
+                $schema->setXml(
+                    (new Xml())->setName('response')
                 );
             }
-            $this->operation->pushResponse($response);
 
-            return;
+            $response->pushContent(
+                (new Content())
+                    ->setSchema($schema)
+                    ->setMimeType($mimeType)
+            );
         }
 
-        if (in_array(strtolower($this->route->getAction()), ['add','view','edit'])) {
-            $response = (new Response())->setCode('200');
+        $this->operation->pushResponse($response);
 
-            foreach ($this->config->getResponseContentTypes() as $mimeType) {
-                if ($mimeType == 'application/xml') {
-                    $schema->setXml((new Xml())->setName('response'));
-                }
-
-                $response->pushContent(
-                    (new Content())
-                        ->setSchema($schema)
-                        ->setMimeType($mimeType)
-                );
-            }
-            $this->operation->pushResponse($response);
-
-            return;
-        }
+        return;
     }
 
     /**

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -233,8 +233,6 @@ class Swagger
                     continue;
                 }
 
-                $this->addArrayOfObjectsSchema($route);
-
                 $schema = $this->getSchemaFromRoute($route);
 
                 $operation = $operationFactory->create($route, $httpMethod, $schema);
@@ -263,47 +261,11 @@ class Swagger
         $controller = $route->getController();
         $name = preg_replace('/\s+/', '', $controller);
 
-        if (in_array(strtolower($route->getAction()), ['index']) && $this->getSchemaByName($name)) {
-            return $this->getSchemaByName($name);
-        }
-
-        if (in_array(strtolower($route->getAction()), ['add','view','edit'])) {
+        if (in_array(strtolower($route->getAction()), ['add','view','edit','index'])) {
             return $this->getSchemaByName(Inflector::singularize($name));
         }
 
         return null;
-    }
-
-    /**
-     * Adds array of objects to #/components/schemas
-     *
-     * @param \SwaggerBake\Lib\Decorator\RouteDecorator $route RouteDecorator
-     * @return void
-     */
-    private function addArrayOfObjectsSchema(RouteDecorator $route): void
-    {
-        if (!in_array('GET', $route->getMethods())) {
-            return;
-        }
-
-        if ($route->getAction() !== 'index') {
-            return;
-        }
-
-        if ($this->getSchemaByName($route->getController())) {
-            return;
-        }
-
-        if (!$this->getSchemaByName(Inflector::singularize($route->getController()))) {
-            return;
-        }
-
-        $this->pushSchema(
-            (new Schema())
-                ->setName($route->getController())
-                ->setType('array')
-                ->setItems(['$ref' => '#/components/schemas/' . Inflector::singularize($route->getController())])
-        );
     }
 
     /**

--- a/tests/TestCase/Lib/SwaggerOperationTest.php
+++ b/tests/TestCase/Lib/SwaggerOperationTest.php
@@ -14,7 +14,9 @@ use SwaggerBake\Lib\Swagger;
 
 class SwaggerOperationTest extends TestCase
 {
-    /** @var string[] */
+    /**
+     * @var string[]
+     */
     public $fixtures = [
         'plugin.SwaggerBake.DepartmentEmployees',
         'plugin.SwaggerBake.Departments',
@@ -22,11 +24,20 @@ class SwaggerOperationTest extends TestCase
         'plugin.SwaggerBake.EmployeeSalaries',
     ];
 
-    /** @var Router  */
+    /**
+     * @var Router
+     */
     private $router;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private $config;
+
+    /**
+     * @var Swagger
+     */
+    private $swagger;
 
     public function setUp(): void
     {
@@ -71,17 +82,18 @@ class SwaggerOperationTest extends TestCase
             ]
         ];
 
+        if (!$this->swagger instanceof Swagger) {
+            $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
+            $cakeRoute = new CakeRoute($this->router, $configuration);
+            $this->swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
+        }
+
         AnnotationLoader::load();
     }
 
     public function testCrudOperationsExist()
     {
-        $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
-
-        $cakeRoute = new CakeRoute($this->router, $configuration);
-        $swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
-
-        $arr = json_decode($swagger->toString(), true);
+        $arr = json_decode($this->swagger->toString(), true);
 
         $this->assertArrayHasKey('get', $arr['paths']['/employees']);
         $this->assertArrayHasKey('post', $arr['paths']['/employees']);
@@ -93,28 +105,19 @@ class SwaggerOperationTest extends TestCase
 
     public function testDefaultResponseSchemaOnIndexMethod()
     {
-        $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
-
-        $cakeRoute = new CakeRoute($this->router, $configuration);
-        $swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
-
-        $arr = json_decode($swagger->toString(), true);
+        $arr = json_decode($this->swagger->toString(), true);
 
         $employee = $arr['paths']['/employees']['get'];
+
         $schema =  $employee['responses'][200]['content']['application/json']['schema'];
 
         $this->assertEquals('array', $schema['type']);
-        $this->assertEquals('#/components/schemas/Employee', $schema['items']['$ref']);
+        $this->assertEquals('#/components/schemas/Employees', $schema['items']['$ref']);
     }
 
     public function testDefaultRequestSchemaOnAddMethod()
     {
-        $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
-
-        $cakeRoute = new CakeRoute($this->router, $configuration);
-        $swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
-
-        $arr = json_decode($swagger->toString(), true);
+        $arr = json_decode($this->swagger->toString(), true);
 
         $employee = $arr['paths']['/employees']['post'];
         $schema =  $employee['requestBody']['content']['application/x-www-form-urlencoded']['schema'];
@@ -125,12 +128,7 @@ class SwaggerOperationTest extends TestCase
 
     public function testDefaultResponseSchemaOnAddMethod()
     {
-        $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
-
-        $cakeRoute = new CakeRoute($this->router, $configuration);
-        $swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
-
-        $arr = json_decode($swagger->toString(), true);
+        $arr = json_decode($this->swagger->toString(), true);
 
         $employee = $arr['paths']['/employees']['post'];
         $schema =  $employee['responses'][200]['content']['application/json']['schema'];
@@ -141,12 +139,7 @@ class SwaggerOperationTest extends TestCase
 
     public function testDefaultRequestSchemaOnEditMethod()
     {
-        $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
-
-        $cakeRoute = new CakeRoute($this->router, $configuration);
-        $swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
-
-        $arr = json_decode($swagger->toString(), true);
+        $arr = json_decode($this->swagger->toString(), true);
 
         $employee = $arr['paths']['/employees/{id}']['patch'];
         $schema =  $employee['requestBody']['content']['application/x-www-form-urlencoded']['schema'];
@@ -157,12 +150,7 @@ class SwaggerOperationTest extends TestCase
 
     public function testDefaultResponseSchemaOnEditMethod()
     {
-        $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
-
-        $cakeRoute = new CakeRoute($this->router, $configuration);
-        $swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
-
-        $arr = json_decode($swagger->toString(), true);
+        $arr = json_decode($this->swagger->toString(), true);
 
         $employee = $arr['paths']['/employees/{id}']['patch'];
         $schema =  $employee['responses'][200]['content']['application/json']['schema'];
@@ -173,24 +161,14 @@ class SwaggerOperationTest extends TestCase
 
     public function testHiddenOperation()
     {
-        $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
-
-        $cakeRoute = new CakeRoute($this->router, $configuration);
-        $swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
-
-        $arr = json_decode($swagger->toString(), true);
+        $arr = json_decode($this->swagger->toString(), true);
 
         $this->assertArrayNotHasKey('/employees/custom-hidden', $arr['paths']);
     }
 
     public function testExceptionResponseSchema()
     {
-        $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
-
-        $cakeRoute = new CakeRoute($this->router, $configuration);
-        $swagger = new Swagger(new CakeModel($cakeRoute, $configuration));
-
-        $arr = json_decode($swagger->toString(), true);
+        $arr = json_decode($this->swagger->toString(), true);
 
         $responses = $arr['paths']['/employees/custom-get']['get']['responses'];
 

--- a/tests/TestCase/Lib/SwaggerOperationTest.php
+++ b/tests/TestCase/Lib/SwaggerOperationTest.php
@@ -112,7 +112,7 @@ class SwaggerOperationTest extends TestCase
         $schema =  $employee['responses'][200]['content']['application/json']['schema'];
 
         $this->assertEquals('array', $schema['type']);
-        $this->assertEquals('#/components/schemas/Employees', $schema['items']['$ref']);
+        $this->assertEquals('#/components/schemas/Employee', $schema['items']['$ref']);
     }
 
     public function testDefaultRequestSchemaOnAddMethod()


### PR DESCRIPTION
See notes in #119

- Combined conditions into a single if for schema and has success code check
- Removed duplicate code fragment for setting Schema on Response->content->schema and mimeType
- Removed duplicate check for whether the action is a CRUD action
- Removes the display of array of objects in OpenAPI schema.
- Logic for showing array of objects on index actions was moved inside Operation->Response->Content->Schema
- Some refactoring and cleanup was also performed in assignSchema()

A bug was found in OperationResponse->assignSchema() related to XML
mime types, setXml(null) is called on each iteration to avoid all mime
types showing XML data.

Improved performance of SwaggerOperationTest by moving not rebuilding
Swagger instance for each test. Methods that need a custom Swagger
instance were left a lone.