### PR TITLE
Deprecated SwagRequestBodyContent->mimeType in favor of mimeTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ public function index() {}
 ```
 
 #### `@SwagRequestBodyContent`
-Method level annotation for describing custom content in request body.
+Method level annotation for describing custom content in request body. The mimeTypes parameter is optional. If empty, 
+all mimeTypes defined as `requestAccepts` in your swagger_bake.php will be used.
 
 - `mimeType` has been deprecated in >= v1.5, use array form with `mimeTypes`
 

--- a/README.md
+++ b/README.md
@@ -298,9 +298,11 @@ public function index() {}
 #### `@SwagRequestBodyContent`
 Method level annotation for describing custom content in request body.
 
+- `mimeType` has been deprecated in >= v1.5, use array form with `mimeTypes`
+
 ```php
 /**
- * @Swag\SwagRequestBodyContent(refEntity="#/components/schemas/Actor", mimeType="application/json")
+ * @Swag\SwagRequestBodyContent(refEntity="#/components/schemas/Actor", mimeTypes={"application/json"})
  */
 public function index() {}
 ```

--- a/src/Lib/Annotation/SwagRequestBodyContent.php
+++ b/src/Lib/Annotation/SwagRequestBodyContent.php
@@ -3,23 +3,38 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Lib\Annotation;
 
+use Cake\Log\Log;
+
 /**
  * @Annotation
  * @Target({"METHOD"})
  * @Attributes({
  * @Attribute("refEntity", type = "string"),
+ * @Attribute("mimeTypes", type = "array"),
  * @Attribute("mimeType", type = "string")
  * })
  */
 class SwagRequestBodyContent
 {
     /**
+     * OpenApi Components.Schema
+     *
      * @var string
+     * @example #/components/schemas/Actor
      */
     public $refEntity;
 
     /**
+     * List of mimeTypes accepted as request bodies
+     *
+     * @var array
+     * @example {"application/json","application/xml"}
+     */
+    public $mimeTypes;
+
+    /**
      * @var string
+     * @deprecated use mimeTypes instead
      */
     public $mimeType;
 
@@ -28,7 +43,16 @@ class SwagRequestBodyContent
      */
     public function __construct(array $values)
     {
+        $values = array_merge(['refEntity' => '', 'mimeTypes' => []], $values);
+
+        if (isset($values['mimeType'])) {
+            array_push($values['mimeTypes'], $values['mimeType']);
+            $msg = 'SwaggerBake: `mimeType` is deprecated, use `mimeTypes` in SwagRequestBodyContent';
+            Log::warning($msg);
+            deprecationWarning($msg);
+        }
+
         $this->refEntity = $values['refEntity'];
-        $this->mimeType = $values['mimeType'];
+        $this->mimeTypes = $values['mimeTypes'];
     }
 }

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -87,7 +87,7 @@ class OperationFromRouteFactory
         $operation = (new OperationQueryParameter())
             ->getOperationWithQueryParameters($operation, $annotations);
 
-        $operation = (new OperationRequestBody($config, $operation, $annotations, $route, $schema))
+        $operation = (new OperationRequestBody($this->swagger, $operation, $annotations, $route, $schema))
             ->getOperationWithRequestBody();
 
         $operation = (new OperationResponse($config, $operation, $docBlock, $annotations, $route, $schema))

--- a/src/Lib/Operation/OperationRequestBody.php
+++ b/src/Lib/Operation/OperationRequestBody.php
@@ -134,11 +134,18 @@ class OperationRequestBody
 
         $requestBody = $this->operation->getRequestBody() ?? new RequestBody();
 
-        $requestBody->pushContent(
-            (new Content())
-                ->setMimeType($swagRequestBodyContent->mimeType)
-                ->setSchema($swagRequestBodyContent->refEntity)
-        );
+        $mimeTypes = $this->config->getRequestAccepts();
+        if (!empty($swagRequestBodyContent->mimeTypes)) {
+            $mimeTypes = $swagRequestBodyContent->mimeTypes;
+        }
+
+        foreach ($mimeTypes as $mimeType) {
+            $requestBody->pushContent(
+                (new Content())
+                    ->setMimeType($mimeType)
+                    ->setSchema($swagRequestBodyContent->refEntity)
+            );
+        }
 
         $this->operation->setRequestBody($requestBody);
     }

--- a/src/Lib/Operation/OperationRequestBody.php
+++ b/src/Lib/Operation/OperationRequestBody.php
@@ -313,7 +313,11 @@ class OperationRequestBody
                 ->getProperties();
         }
 
-        $schema = clone $this->schema;
+        $schema = $this->getSchemaWithWritablePropertiesOnly($this->schema);
+
+        $properties = array_merge($schema->getProperties(), $properties);
+
+        $schema->setProperties($properties);
 
         $requestBody->pushContent(
             (new Content())

--- a/src/Lib/Operation/OperationRequestBody.php
+++ b/src/Lib/Operation/OperationRequestBody.php
@@ -7,7 +7,7 @@ use SwaggerBake\Lib\Annotation\SwagDto;
 use SwaggerBake\Lib\Annotation\SwagForm;
 use SwaggerBake\Lib\Annotation\SwagRequestBody;
 use SwaggerBake\Lib\Annotation\SwagRequestBodyContent;
-use SwaggerBake\Lib\Configuration;
+use SwaggerBake\Lib\Swagger;
 use SwaggerBake\Lib\Decorator\RouteDecorator;
 use SwaggerBake\Lib\OpenApi\Content;
 use SwaggerBake\Lib\OpenApi\Operation;
@@ -24,9 +24,9 @@ use SwaggerBake\Lib\OpenApi\Xml;
 class OperationRequestBody
 {
     /**
-     * @var \SwaggerBake\Lib\Configuration
+     * @var \SwaggerBake\Lib\Swagger
      */
-    private $config;
+    private $swagger;
 
     /**
      * @var \SwaggerBake\Lib\OpenApi\Operation
@@ -49,24 +49,30 @@ class OperationRequestBody
     private $schema;
 
     /**
-     * @param \SwaggerBake\Lib\Configuration $config Configuration
+     * @var \SwaggerBake\Lib\Configuration
+     */
+    private $config;
+
+    /**
+     * @param \SwaggerBake\Lib\Swagger $swagger Swagger
      * @param \SwaggerBake\Lib\OpenApi\Operation $operation Operation
      * @param array $annotations Array of annotation objects
      * @param \SwaggerBake\Lib\Decorator\RouteDecorator $route RouteDecorator
      * @param \SwaggerBake\Lib\OpenApi\Schema|null $schema Schema
      */
     public function __construct(
-        Configuration $config,
+        Swagger $swagger,
         Operation $operation,
         array $annotations,
         RouteDecorator $route,
         ?Schema $schema
     ) {
-        $this->config = $config;
+        $this->swagger = $swagger;
         $this->operation = $operation;
         $this->annotations = $annotations;
         $this->route = $route;
         $this->schema = $schema;
+        $this->config = $swagger->getConfig();
     }
 
     /**
@@ -139,12 +145,24 @@ class OperationRequestBody
             $mimeTypes = $swagRequestBodyContent->mimeTypes;
         }
 
-        foreach ($mimeTypes as $mimeType) {
-            $requestBody->pushContent(
-                (new Content())
-                    ->setMimeType($mimeType)
-                    ->setSchema($swagRequestBodyContent->refEntity)
+        if (!empty($swagRequestBodyContent->refEntity)) {
+            $pieces = explode('/', $swagRequestBodyContent->refEntity);
+            $entity = end($pieces);
+            $schema = $this->getSchemaWithWritablePropertiesOnly(
+                $this->swagger->getSchemaByName($entity)
             );
+        }
+
+        foreach ($mimeTypes as $mimeType) {
+            $content = (new Content())->setMimeType($mimeType);
+
+            if (isset($schema)) {
+                $content->setSchema($schema);
+            } else {
+                $content->setSchema($swagRequestBodyContent->refEntity);
+            }
+
+            $requestBody->pushContent($content);
         }
 
         $this->operation->setRequestBody($requestBody);
@@ -253,19 +271,7 @@ class OperationRequestBody
                 continue;
             }
 
-            $schema = clone $this->schema;
-            $schemaProperties = array_filter($schema->getProperties(), function ($property) {
-                return $property->isReadOnly() === false;
-            });
-
-            foreach ($schemaProperties as $schemaProperty) {
-                if ($this->route->getAction() == 'edit' && $schemaProperty->isRequirePresenceOnUpdate()) {
-                    $schemaProperty->setRequired(true);
-                } elseif ($this->route->getAction() == 'add' && $schemaProperty->isRequirePresenceOnCreate()) {
-                    $schemaProperty->setRequired(true);
-                }
-                $schema->pushProperty($schemaProperty);
-            }
+            $schema = $this->getSchemaWithWritablePropertiesOnly($this->schema);
 
             if ($mimeType == 'application/xml') {
                 $schema->setXml(
@@ -308,21 +314,6 @@ class OperationRequestBody
         }
 
         $schema = clone $this->schema;
-        $schemaProperties = array_filter($schema->getProperties(), function ($property) {
-            return $property->isReadOnly() === false;
-        });
-
-        foreach ($schemaProperties as $schemaProperty) {
-            if ($this->route->getAction() == 'edit' && $schemaProperty->isRequirePresenceOnUpdate()) {
-                $schemaProperty->setRequired(true);
-            } elseif ($this->route->getAction() == 'add' && $schemaProperty->isRequirePresenceOnCreate()) {
-                $schemaProperty->setRequired(true);
-            }
-        }
-
-        $properties = array_merge($schemaProperties, $properties);
-
-        $schema->setProperties($properties);
 
         $requestBody->pushContent(
             (new Content())
@@ -331,5 +322,34 @@ class OperationRequestBody
         );
 
         return $requestBody;
+    }
+
+    /**
+     * Returns new Schema instance with only writable properties
+     *
+     * @param Schema $schema
+     * @return Schema
+     */
+    private function getSchemaWithWritablePropertiesOnly(Schema $schema): Schema
+    {
+        $newSchema = clone $schema;
+        $newSchema->setProperties([]);
+
+        $schemaProperties = array_filter($schema->getProperties(), function ($property) {
+            return $property->isReadOnly() === false;
+        });
+
+        $httpMethods = $this->route->getMethods();
+
+        foreach ($schemaProperties as $schemaProperty) {
+            if (count(array_intersect($httpMethods, ['PUT','PATCH'])) > 1 && $schemaProperty->isRequirePresenceOnUpdate()) {
+                $schemaProperty->setRequired(true);
+            } elseif (count(array_intersect($httpMethods, ['POST'])) > 1 && $schemaProperty->isRequirePresenceOnCreate()) {
+                $schemaProperty->setRequired(true);
+            }
+            $newSchema->pushProperty($schemaProperty);
+        }
+
+        return $newSchema;
     }
 }

--- a/tests/TestCase/Lib/Annotations/SwagRequestBodyContentTest.php
+++ b/tests/TestCase/Lib/Annotations/SwagRequestBodyContentTest.php
@@ -26,12 +26,22 @@ class SwagRequestBodyContentTest extends TestCase
         $router = new Router();
         $router::scope('/api', function (RouteBuilder $builder) {
             $builder->setExtensions(['json']);
-            $builder->resources('Employees', [
+            $builder->resources('SwagRequestBodyContent', [
                 'map' => [
-                    'customRequestBodyContent' => [
-                        'action' => 'customRequestBodyContent',
+                    'textPlain' => [
+                        'action' => 'textPlain',
                         'method' => 'POST',
-                        'path' => 'custom-request-body-content'
+                        'path' => 'text-plain'
+                    ],
+                    'multipleMimeTypes' => [
+                        'action' => 'multipleMimeTypes',
+                        'method' => 'POST',
+                        'path' => 'multiple-mime-types'
+                    ],
+                    'useConfigDefaults' => [
+                        'action' => 'useConfigDefaults',
+                        'method' => 'POST',
+                        'path' => 'use-config-defaults'
                     ],
                 ]
             ]);
@@ -45,7 +55,7 @@ class SwagRequestBodyContentTest extends TestCase
             'webPath' => '/swagger.json',
             'hotReload' => false,
             'exceptionSchema' => 'Exception',
-            'requestAccepts' => ['application/x-www-form-urlencoded'],
+            'requestAccepts' => ['application/x-www-form-urlencoded','application/xml','application/json'],
             'responseContentTypes' => ['application/json'],
             'namespaces' => [
                 'controllers' => ['\SwaggerBakeTest\App\\'],
@@ -64,9 +74,32 @@ class SwagRequestBodyContentTest extends TestCase
         $swagger = new Swagger(new CakeModel($cakeRoute, $this->config));
         $arr = json_decode($swagger->toString(), true);
 
-        $operation = $arr['paths']['/employees/custom-request-body-content']['post'];
+        $operation = $arr['paths']['/swag-request-body-content/text-plain']['post'];
 
         $this->assertArrayHasKey('schema', $operation['requestBody']['content']['text/plain']);
     }
 
+    public function testMultipleMimeTypes()
+    {
+        $cakeRoute = new CakeRoute($this->router, $this->config);
+
+        $swagger = new Swagger(new CakeModel($cakeRoute, $this->config));
+        $arr = json_decode($swagger->toString(), true);
+
+        $operation = $arr['paths']['/swag-request-body-content/multiple-mime-types']['post'];
+
+        $this->assertCount(2, $operation['requestBody']['content']);
+    }
+
+    public function testUseMimeTypesFromConfig()
+    {
+        $cakeRoute = new CakeRoute($this->router, $this->config);
+
+        $swagger = new Swagger(new CakeModel($cakeRoute, $this->config));
+        $arr = json_decode($swagger->toString(), true);
+
+        $operation = $arr['paths']['/swag-request-body-content/use-config-defaults']['post'];
+
+        $this->assertCount(3, $operation['requestBody']['content']);
+    }
 }

--- a/tests/TestCase/Lib/Operation/OperationRequestBodyTest.php
+++ b/tests/TestCase/Lib/Operation/OperationRequestBodyTest.php
@@ -8,12 +8,14 @@ use Cake\TestSuite\TestCase;
 use phpDocumentor\Reflection\DocBlockFactory;
 use SwaggerBake\Lib\Annotation\SwagDto;
 use SwaggerBake\Lib\Annotation\SwagForm;
+use SwaggerBake\Lib\CakeModel;
 use SwaggerBake\Lib\CakeRoute;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\OpenApi\Operation;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
 use SwaggerBake\Lib\Operation\OperationRequestBody;
+use SwaggerBake\Lib\Swagger;
 
 class OperationRequestBodyTest extends TestCase
 {
@@ -57,12 +59,14 @@ class OperationRequestBodyTest extends TestCase
     {
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new CakeRoute($this->router, $config);
+        $cakeModels = new CakeModel($cakeRoute, $config);
+        $swagger = new Swagger($cakeModels);
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];
 
         $operationRequestBody = new OperationRequestBody(
-            $config,
+            $swagger,
             (new Operation())->setHttpMethod('POST'),
             [
                 new SwagForm(['name' => 'test', 'type' => 'string', 'description' => '', 'required' => false])
@@ -87,12 +91,14 @@ class OperationRequestBodyTest extends TestCase
     {
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new CakeRoute($this->router, $config);
+        $cakeModels = new CakeModel($cakeRoute, $config);
+        $swagger = new Swagger($cakeModels);
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];
 
         $operationRequestBody = new OperationRequestBody(
-            $config,
+            $swagger,
             (new Operation())->setHttpMethod('POST'),
             [
                 new SwagDto(['class' => '\SwaggerBakeTest\App\Dto\EmployeeData'])
@@ -118,6 +124,8 @@ class OperationRequestBodyTest extends TestCase
     {
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new CakeRoute($this->router, $config);
+        $cakeModels = new CakeModel($cakeRoute, $config);
+        $swagger = new Swagger($cakeModels);
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];
@@ -133,7 +141,7 @@ class OperationRequestBodyTest extends TestCase
         ;
 
         $operationRequestBody = new OperationRequestBody(
-            $config,
+            $swagger,
             (new Operation())->setHttpMethod('POST'),
             [],
             $route,

--- a/tests/test_app/src/Controller/EmployeesController.php
+++ b/tests/test_app/src/Controller/EmployeesController.php
@@ -148,16 +148,6 @@ class EmployeesController extends AppController
     }
 
     /**
-     * @Swag\SwagRequestBodyContent(refEntity="", mimeType="text/plain")
-     */
-    public function customRequestBodyContent()
-    {
-        $hello = 'world';
-        $this->set(compact('hello'));
-        $this->viewBuilder()->setOption('serialize', ['hello']);
-    }
-
-    /**
      * @Swag\SwagResponseSchema(refEntity="#/components/schemas/Pet")
      * @Swag\SwagResponseSchema(refEntity="", description="deprecated httpCode still works", httpCode=400)
      * @Swag\SwagResponseSchema(refEntity="", description="new statusCode", statusCode="404")

--- a/tests/test_app/src/Controller/SwagRequestBodyContentController.php
+++ b/tests/test_app/src/Controller/SwagRequestBodyContentController.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace SwaggerBakeTest\App\Controller;
+
+use SwaggerBake\Lib\Annotation as Swag;
+use SwaggerBake\Lib\Extension\CakeSearch\Annotation\SwagSearch;
+
+class SwagRequestBodyContentController extends AppController
+{
+    /**
+     * @Swag\SwagRequestBodyContent(refEntity="", mimeTypes={"text/plain"})
+     */
+    public function textPlain()
+    {
+
+    }
+
+    /**
+     * @Swag\SwagRequestBodyContent(refEntity="", mimeTypes={"text/plain","application/xml"})
+     */
+    public function multipleMimeTypes()
+    {
+
+    }
+
+    /**
+     * @Swag\SwagRequestBodyContent(refEntity="")
+     */
+    public function useConfigDefaults()
+    {
+
+    }
+}


### PR DESCRIPTION
Deprecated SwagRequestBodyContent->mimeType in favor of mimeTypes

Accept an array for mimeTypes to reduce the amount of annotations needed