### PR TITLE
Feature/issue 112 additional http methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,12 @@ public function index() {}
 ```
 
 #### `@SwagOperation`
-Method level annotation for OpenApi Operations. Toggle visibility with isVisible and customize tag names which default 
-to the controllers name.
+Method level annotation for OpenApi Operations. [Read the comments](src/Lib/Annotation/SwagOperation.php) for examples 
+and further explanations.
 
 ```php
 /**
- * @SwagOperation(isVisible=false, tagNames={"MyTag","AnotherTag"})
+ * @SwagOperation(isVisible=false, tagNames={"MyTag","AnotherTag"}, showPut=false)
  */
 public function index() {}
 ```

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ and further explanations.
 
 ```php
 /**
- * @SwagOperation(isVisible=false, tagNames={"MyTag","AnotherTag"}, showPut=false)
+ * @Swag\SwagOperation(isVisible=false, tagNames={"MyTag","AnotherTag"}, showPut=false)
  */
 public function index() {}
 ```

--- a/src/Lib/Annotation/SwagOperation.php
+++ b/src/Lib/Annotation/SwagOperation.php
@@ -37,7 +37,6 @@ namespace SwaggerBake\Lib\Annotation;
  *   put:
  *     summary: PUT method
  * ```
- *
  * @see https://swagger.io/docs/specification/paths-and-operations/
  */
 class SwagOperation

--- a/src/Lib/Annotation/SwagOperation.php
+++ b/src/Lib/Annotation/SwagOperation.php
@@ -10,8 +10,34 @@ namespace SwaggerBake\Lib\Annotation;
  * @Target({"METHOD"})
  * @Attributes({
  * @Attribute("isVisible", type="bool"),
- * @Attribute("tagNames", type="array")
+ * @Attribute("tagNames", type="array"),
+ * @Attribute("showPut", type="bool")
  * })
+ *
+ * Example: Hide an operation from OpenAPI output and Swagger/Redoc views
+ *
+ * `@Swag\SwagOperation(isVisible=false)`
+ *
+ * Example: Change default tag names of an operation. By default the controllers name is used as the tag.
+ *
+ * `@Swag\SwagOperation(tagNames={"Custom","Tags"})`
+ *
+ * ```yaml
+ *   get:
+ *     tags:
+ *       - Custom
+ *       - Tags
+ * ```
+ *
+ * Example: Show HTTP PUT operations on controller::edit() actions. By default on PATCH is displayed.
+ *
+ * `@Swag\SwagOperation(showPut=true)`
+ *
+ * ```yaml
+ *   put:
+ *     summary: PUT method
+ * ```
+ *
  * @see https://swagger.io/docs/specification/paths-and-operations/
  */
 class SwagOperation
@@ -36,12 +62,23 @@ class SwagOperation
     public $tagNames;
 
     /**
+     * Allows HTTP PUT on controller::edit crud action, default is false
+     *
+     * @var bool
+     */
+    public $showPut = false;
+
+    /**
      * @param array $values Annotation attributes as key-value pair
      */
     public function __construct(array $values)
     {
-        $values = array_merge(['isVisible' => true, 'tagNames' => [], 'httpMethod' => null], $values);
+        $values = array_merge(
+            ['isVisible' => true, 'tagNames' => [], 'httpMethod' => null, 'showPut' => false],
+            $values
+        );
         $this->isVisible = (bool)$values['isVisible'];
         $this->tagNames = $values['tagNames'];
+        $this->showPut = (bool)$values['showPut'];
     }
 }

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -152,7 +152,7 @@ class OperationFromRouteFactory
     /**
      * Is the HTTP PUT allowed on the CRUD edit action?
      *
-     * @param RouteDecorator $route instance of RouteDecorator
+     * @param \SwaggerBake\Lib\Decorator\RouteDecorator $route instance of RouteDecorator
      * @param string $httpMethod http method (PUT, POST, PATCH etc..)
      * @param array $annotations an array of annotation objects
      * @return bool

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -60,7 +60,7 @@ class OperationFromRouteFactory
         $docBlock = $this->getDocBlock($fqns, $route->getAction());
         $annotations = AnnotationUtility::getMethodAnnotations($fqns, $route->getAction());
 
-        if (!$this->isPutAllowed($route, $httpMethod, $annotations) || !$this->isVisible($annotations)) {
+        if (!$this->isAllowed($route, $httpMethod, $annotations) || !$this->isVisible($annotations)) {
             return null;
         }
 
@@ -150,14 +150,15 @@ class OperationFromRouteFactory
     }
 
     /**
-     * Is the HTTP PUT allowed on the CRUD edit action?
+     * Is the route, http method, and annotation combination allowed? This primarily prevents HTTP PUT methods from
+     * appearing in OpenAPI schema unless by default.
      *
      * @param \SwaggerBake\Lib\Decorator\RouteDecorator $route instance of RouteDecorator
      * @param string $httpMethod http method (PUT, POST, PATCH etc..)
      * @param array $annotations an array of annotation objects
      * @return bool
      */
-    private function isPutAllowed(RouteDecorator $route, string $httpMethod, array $annotations): bool
+    private function isAllowed(RouteDecorator $route, string $httpMethod, array $annotations): bool
     {
         if (strtoupper($httpMethod) !== 'PUT' || $route->getAction() !== 'edit') {
             return true;

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -150,8 +150,8 @@ class OperationFromRouteFactory
     }
 
     /**
-     * Is the route, http method, and annotation combination allowed? This primarily prevents HTTP PUT methods from
-     * appearing in OpenAPI schema unless by default.
+     * Is the route, http method, and annotation combination allowed? This primarily prevents HTTP PUT methods on
+     * controller `edit()` actions from appearing in OpenAPI schema by default.
      *
      * @param \SwaggerBake\Lib\Decorator\RouteDecorator $route instance of RouteDecorator
      * @param string $httpMethod http method (PUT, POST, PATCH etc..)

--- a/src/Lib/Operation/OperationRequestBody.php
+++ b/src/Lib/Operation/OperationRequestBody.php
@@ -7,7 +7,6 @@ use SwaggerBake\Lib\Annotation\SwagDto;
 use SwaggerBake\Lib\Annotation\SwagForm;
 use SwaggerBake\Lib\Annotation\SwagRequestBody;
 use SwaggerBake\Lib\Annotation\SwagRequestBodyContent;
-use SwaggerBake\Lib\Swagger;
 use SwaggerBake\Lib\Decorator\RouteDecorator;
 use SwaggerBake\Lib\OpenApi\Content;
 use SwaggerBake\Lib\OpenApi\Operation;
@@ -15,6 +14,7 @@ use SwaggerBake\Lib\OpenApi\RequestBody;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
 use SwaggerBake\Lib\OpenApi\Xml;
+use SwaggerBake\Lib\Swagger;
 
 /**
  * Class OperationRequestBody
@@ -331,8 +331,8 @@ class OperationRequestBody
     /**
      * Returns new Schema instance with only writable properties
      *
-     * @param Schema $schema
-     * @return Schema
+     * @param \SwaggerBake\Lib\OpenApi\Schema $schema instance of Schema
+     * @return \SwaggerBake\Lib\OpenApi\Schema
      */
     private function getSchemaWithWritablePropertiesOnly(Schema $schema): Schema
     {
@@ -346,9 +346,12 @@ class OperationRequestBody
         $httpMethods = $this->route->getMethods();
 
         foreach ($schemaProperties as $schemaProperty) {
-            if (count(array_intersect($httpMethods, ['PUT','PATCH'])) > 1 && $schemaProperty->isRequirePresenceOnUpdate()) {
+            $requireOnUpdate = $schemaProperty->isRequirePresenceOnUpdate();
+            $requireOnCreate = $schemaProperty->isRequirePresenceOnCreate();
+
+            if (count(array_intersect($httpMethods, ['PUT','PATCH'])) > 1 && $requireOnUpdate) {
                 $schemaProperty->setRequired(true);
-            } elseif (count(array_intersect($httpMethods, ['POST'])) > 1 && $schemaProperty->isRequirePresenceOnCreate()) {
+            } elseif (count(array_intersect($httpMethods, ['POST'])) > 1 && $requireOnCreate) {
                 $schemaProperty->setRequired(true);
             }
             $newSchema->pushProperty($schemaProperty);

--- a/tests/TestCase/Lib/Operation/OperationFromRouteFactoryTest.php
+++ b/tests/TestCase/Lib/Operation/OperationFromRouteFactoryTest.php
@@ -27,7 +27,7 @@ class OperationFromRouteFactoryTest extends TestCase
         $router::scope('/api', function (RouteBuilder $builder) {
             $builder->setExtensions(['json']);
             $builder->resources('Employees', [
-                'only' => ['index','edit']
+                'only' => ['index','update']
             ]);
         });
         $this->router = $router;
@@ -76,12 +76,10 @@ class OperationFromRouteFactoryTest extends TestCase
         $cakeRoute = new CakeRoute($this->router, $config);
 
         $routes = $cakeRoute->getRoutes();
-        $route = reset($routes);
-
-        $operation = (new OperationFromRouteFactory($swagger))->create($route, 'PUT', null);
+        $operation = (new OperationFromRouteFactory($swagger))->create($routes['employees:edit'], 'PUT', null);
 
         $this->assertInstanceOf(Operation::class, $operation);
         $this->assertEquals('PUT', $operation->getHttpMethod());
-        $this->assertEquals('employees:index:put', $operation->getOperationId());
+        $this->assertEquals('employees:edit:put', $operation->getOperationId());
     }
 }

--- a/tests/TestCase/Lib/Operation/OperationFromRouteFactoryTest.php
+++ b/tests/TestCase/Lib/Operation/OperationFromRouteFactoryTest.php
@@ -27,7 +27,7 @@ class OperationFromRouteFactoryTest extends TestCase
         $router::scope('/api', function (RouteBuilder $builder) {
             $builder->setExtensions(['json']);
             $builder->resources('Employees', [
-                'only' => 'index'
+                'only' => ['index','edit']
             ]);
         });
         $this->router = $router;
@@ -64,5 +64,24 @@ class OperationFromRouteFactoryTest extends TestCase
         $this->assertEquals('GET', $operation->getHttpMethod());
         $this->assertEquals('employees:index:get', $operation->getOperationId());
         $this->assertEquals('CustomTag', $operation->getTags()[1]);
+    }
+
+    /**
+     * Tests `@SwagOperation(showPut=true)`
+     */
+    public function testShowPut()
+    {
+        $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
+        $swagger = (new SwaggerFactory($config))->create();
+        $cakeRoute = new CakeRoute($this->router, $config);
+
+        $routes = $cakeRoute->getRoutes();
+        $route = reset($routes);
+
+        $operation = (new OperationFromRouteFactory($swagger))->create($route, 'PUT', null);
+
+        $this->assertInstanceOf(Operation::class, $operation);
+        $this->assertEquals('PUT', $operation->getHttpMethod());
+        $this->assertEquals('employees:index:put', $operation->getOperationId());
     }
 }

--- a/tests/TestCase/Lib/Operation/OperationFromRouteFactoryTest.php
+++ b/tests/TestCase/Lib/Operation/OperationFromRouteFactoryTest.php
@@ -58,7 +58,7 @@ class OperationFromRouteFactoryTest extends TestCase
         $routes = $cakeRoute->getRoutes();
         $route = reset($routes);
 
-        $operation = (new OperationFromRouteFactory($swagger))->create($route, 'GET', null);
+        $operation = (new OperationFromRouteFactory($swagger))->create($routes['employees:index'], 'GET', null);
 
         $this->assertInstanceOf(Operation::class, $operation);
         $this->assertEquals('GET', $operation->getHttpMethod());

--- a/tests/test_app/src/Controller/EmployeesController.php
+++ b/tests/test_app/src/Controller/EmployeesController.php
@@ -80,6 +80,7 @@ class EmployeesController extends AppController
     /**
      * Edit method
      *
+     * @Swag\SwagOperation(showPut=true)
      * @param string|null $id Employee id.
      * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.


### PR DESCRIPTION
Allows HTTP PUT methods on controller:edit actions

**Testing**
Add `@SwagOperation(showPut=true)` to controller:edit actions which require HTTP PUT.