### PR TITLE
Add SwagResponseSchema->mimeTypes <array> and deprecated mimeType

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,14 +312,15 @@ public function index() {}
 Method level annotation for defining response schema. [Read the comments](src/Lib/Annotation/SwagResponseSchema.php) to 
 see all supported properties and additional examples.
 
-- `httpCode` is deprecated in >= v1.3, use `statusCode`
+- `mimeType` is deprecated in >= v1.5, use `mimeTypes` as an array.
+- `httpCode` is deprecated in >= v1.3, use `statusCode` 
 
 ```php
 /**
  * @Swag\SwagResponseSchema(refEntity="#/components/schemas/Actor", description="Summary", statusCode="200")
  * @Swag\SwagResponseSchema(refEntity="#/components/schemas/Exception", description="Range status codes", statusCode="5XX")
  * @Swag\SwagResponseSchema(schemaItems={"$ref"="#/components/schemas/Pet"})
- * @Swag\SwagResponseSchema(mimeType="text/plain", schemaFormat="date-time")
+ * @Swag\SwagResponseSchema(mimeTypes={"text/plain"}, schemaFormat="date-time")
  */
 public function index() {}
 ```

--- a/src/Lib/Annotation/SwagResponseSchema.php
+++ b/src/Lib/Annotation/SwagResponseSchema.php
@@ -16,6 +16,7 @@ use Cake\Log\Log;
  * @Attribute("statusCode", type = "string"),
  * @Attribute("description", type = "string"),
  * @Attribute("mimeType", type = "string"),
+ * @Attribute("mimeTypes", type = "string"),
  * @Attribute("schemaType", type = "string"),
  * @Attribute("schemaFormat", type = "string"),
  * @Attribute("schemaItems", type = "array")
@@ -53,7 +54,7 @@ use Cake\Log\Log;
  *
  * Example: Defining an HTTP 400-410 exception schema in XML
  *
- * `@Swag\SwagResponseSchema(refEntity="#/components/schemas/Exception", mimeType="application/xml", statusCode="40x")`
+ * `@Swag\SwagResponseSchema(refEntity="#/components/schemas/Exception", mimeTypes={"application/xml"}, statusCode="40x")`
  *
  * ```yaml
  *      responses:
@@ -68,7 +69,7 @@ use Cake\Log\Log;
  *
  * Example: Defining a `text/plain` response with `date-time` format.
  *
- * `@Swag\SwagResponseSchema(mimeType="text/plain", schemaFormat="date-time")`
+ * `@Swag\SwagResponseSchema(mimeTypes={"text/plain"}, schemaFormat="date-time")`
  *
  * ```yaml
  *      responses:
@@ -113,8 +114,17 @@ class SwagResponseSchema
      *
      * @var string
      * @example application/json
+     * @deprecated use $mimeTypes
      */
     public $mimeType;
+
+    /**
+     * Response Content mime types
+     *
+     * @var array
+     * @example mimeTypes={"application/json","application/xml"}
+     */
+    public $mimeTypes;
 
     /**
      * The data type of the schema
@@ -153,6 +163,7 @@ class SwagResponseSchema
         'statusCode' => '200',
         'description' => '',
         'mimeType' => '',
+        'mimeTypes' => [],
         'schemaType' => '',
         'schemaFormat' => '',
         'schemaItems' => [],
@@ -170,6 +181,13 @@ class SwagResponseSchema
             deprecationWarning($msg);
         }
 
+        if (isset($values['mimeType'])) {
+            array_push($values['mimeTypes'], $values['mimeType']);
+            $msg = 'SwaggerBake: `mimeType` is deprecated, use `mimeTypes` in SwagResponseSchema';
+            Log::warning($msg);
+            deprecationWarning($msg);
+        }
+
         if (isset($values['statusCode'])) {
             $this->httpCode = $values['statusCode'];
         }
@@ -178,7 +196,7 @@ class SwagResponseSchema
 
         $this->refEntity = $values['refEntity'];
         $this->description = $values['description'];
-        $this->mimeType = $values['mimeType'];
+        $this->mimeTypes = $values['mimeTypes'];
         $this->schemaType = $values['schemaType'];
         $this->schemaFormat = $values['schemaFormat'];
         $this->schemaItems = $values['schemaItems'];

--- a/tests/TestCase/Lib/Operation/OperationResponseTest.php
+++ b/tests/TestCase/Lib/Operation/OperationResponseTest.php
@@ -258,7 +258,7 @@ class OperationResponseTest extends TestCase
             DocBlockFactory::createInstance()->create('/** */'),
             [
                 new SwagResponseSchema([
-                    'mimeType' => 'text/plain',
+                    'mimeTypes' => ['text/plain'],
                     'schemaFormat' => 'date-time'
                 ]),
             ],


### PR DESCRIPTION
Accept an array instead to reduce the amount of annotations. If no mimeTypes
is supplied, default to values in config responseContentTypes.

- Update README
- Update unit tests