### PR TITLE
Adds support for `ref` to parameter annotations #175

### DIFF
--- a/src/Lib/Annotation/AbstractParameter.php
+++ b/src/Lib/Annotation/AbstractParameter.php
@@ -10,12 +10,20 @@ use SwaggerBake\Lib\Utility\OpenApiDataType;
 /**
  * Read OpenAPI specification for exact usage of the attributes:
  *
+ * @see http://spec.openapis.org/oas/v3.0.3#fixed-fields-9
  * @see https://swagger.io/specification/ search for "Parameter Object"
  * @see https://swagger.io/docs/specification/data-models/data-types/?sbsearch=Data%20Format search for "data format"
  */
 abstract class AbstractParameter
 {
     /**
+     * @var string
+     */
+    public $ref;
+
+    /**
+     * The name of the parameter. Parameter names are case sensitive.
+     *
      * @var string
      */
     public $name;
@@ -26,11 +34,15 @@ abstract class AbstractParameter
     public $type = 'string';
 
     /**
+     * A brief description of the parameter. This could contain examples of use.
+     *
      * @var string
      */
     public $description = '';
 
     /**
+     * Determines whether this parameter is mandatory.
+     *
      * @var bool
      */
     public $required = false;
@@ -41,26 +53,39 @@ abstract class AbstractParameter
     public $enum = [];
 
     /**
+     * Specifies that a parameter is deprecated and SHOULD be transitioned out of usage. Default value is false.
+     *
      * @var bool
      */
     public $deprecated = false;
 
     /**
+     * Sets the ability to pass empty-valued parameters. This is valid only for query parameters and allows
+     * sending a parameter with an empty value.
+     *
      * @var bool
      */
     public $allowEmptyValue = false;
 
     /**
+     * When this is true, parameter values of type array or object generate separate parameters for each value of
+     * the array or key-value pair of the map.
+     *
      * @var bool
      */
     public $explode = false;
 
     /**
+     * Describes how the parameter value will be serialized depending on the type of the parameter value.
+     *
      * @var string
      */
     public $style = '';
 
     /**
+     * Determines whether the parameter value SHOULD allow reserved characters, as defined by [RFC3986]
+     * :/?#[]@!$&'()*+,;= to be included without percent-encoding.
+     *
      * @var bool
      */
     public $allowReserved = false;
@@ -71,6 +96,9 @@ abstract class AbstractParameter
     public $format = '';
 
     /**
+     * Example of the parameter’s potential value. The example SHOULD match the specified schema and encoding
+     * properties if present.
+     *
      * @var mixed
      */
     public $example;
@@ -80,8 +108,8 @@ abstract class AbstractParameter
      */
     public function __construct(array $values)
     {
-        if (!isset($values['name'])) {
-            throw new InvalidArgumentException('Name parameter is required');
+        if (!isset($values['name']) && !isset($values['ref'])) {
+            throw new InvalidArgumentException('`name` or `ref` parameter is required');
         }
 
         $name = $values['name'];

--- a/src/Lib/Annotation/README.md
+++ b/src/Lib/Annotation/README.md
@@ -168,6 +168,7 @@ to see all supported OpenAPI properties.
  * @Swag\SwagQuery(name="one", required=true, description="example description")
  * @Swag\SwagQuery(name="two", type="string", explode=true)
  * @Swag\SwagQuery(name="three", enum={"A","B","C"}, deprecated=true)
+ * @Swag\SwagQuery(ref="#/x-my-project/components/parameters/my-parameter")
  */
 public function index() {}
 ```
@@ -196,6 +197,7 @@ OpenAPI:
               - A
               - B
               - C
+        - $ref: #/x-my-project/components/parameters/my-parameter
 ```
 
 ### @SwagForm
@@ -285,6 +287,7 @@ to see all supported OpenAPI properties.
 ```php
 /**
  * @Swag\SwagHeader(name="X-HEAD-ATTRIBUTE", type="string", description="example")
+ * @Swag\SwagHeader(ref="#/x-my-project/components/parameters/my-header") 
  */
 public function index() {}
 ```
@@ -298,6 +301,7 @@ OpenAPI:
          description: summary
          schema:
            type: string
+       - $ref: #/x-my-project/components/parameters/my-header
 ```
 
 ### @SwagPathParameter

--- a/src/Lib/Factory/ParameterFromAnnotationFactory.php
+++ b/src/Lib/Factory/ParameterFromAnnotationFactory.php
@@ -20,7 +20,8 @@ class ParameterFromAnnotationFactory
     public function create(AbstractParameter $annotation): Parameter
     {
         $parameter = (new Parameter())
-            ->setName($annotation->name)
+            ->setRef($annotation->ref ?? '')
+            ->setName($annotation->name ?? '')
             ->setDescription($annotation->description)
             ->setRequired($annotation->required)
             ->setDeprecated($annotation->deprecated)

--- a/src/Lib/OpenApi/Operation.php
+++ b/src/Lib/OpenApi/Operation.php
@@ -251,7 +251,14 @@ class Operation implements JsonSerializable
      */
     public function pushParameter(Parameter $parameter)
     {
-        $this->parameters[$parameter->getIn() . ':' . $parameter->getName()] = $parameter;
+        if (!empty($parameter->getRef())) {
+            $name = preg_replace('/^\W/', '', str_replace('/', '-', $parameter->getRef()));
+            $name = substr($name, 1);
+        } else {
+            $name = $parameter->getName();
+        }
+
+        $this->parameters[$parameter->getIn() . ':' . $name] = $parameter;
 
         return $this;
     }

--- a/src/Lib/OpenApi/Parameter.php
+++ b/src/Lib/OpenApi/Parameter.php
@@ -18,6 +18,13 @@ class Parameter implements JsonSerializable
     public const IN = ['query','cookie','header','path','body'];
 
     /**
+     * For referencing an OpenAPI YAML object. If set only ref will be returned
+     *
+     * @var string|null
+     */
+    private $ref;
+
+    /**
      * @var string
      **/
     private $name = '';
@@ -91,11 +98,16 @@ class Parameter implements JsonSerializable
     {
         $vars = $this->toArray();
 
+        if (!empty($this->ref)) {
+            return ['$ref' => $this->ref];
+        }
+
         if ($vars['in'] !== 'query') {
             unset($vars['allowReserved']);
         }
 
-        foreach (['style','description','schema','example'] as $property) {
+        // remove empty values from JSON
+        foreach (['style','description','schema','example','ref'] as $property) {
             if (empty($vars[$property])) {
                 unset($vars[$property]);
             }
@@ -110,6 +122,25 @@ class Parameter implements JsonSerializable
         }
 
         return $vars;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getRef(): ?string
+    {
+        return $this->ref;
+    }
+
+    /**
+     * @param string $ref a ref string such (e.g. #/x-my-project/components/parameters/my-header)
+     * @return $this
+     */
+    public function setRef(string $ref)
+    {
+        $this->ref = $ref;
+
+        return $this;
     }
 
     /**

--- a/src/Lib/Operation/OperationQueryParameter.php
+++ b/src/Lib/Operation/OperationQueryParameter.php
@@ -75,7 +75,7 @@ class OperationQueryParameter
         }
 
         $this->definePagination();
-        $this->defineQueryParametersFromAnnotations();
+        $this->defineFromAnnotations();
 
         try {
             $this->defineDataTransferObjectFromAnnotations();
@@ -165,7 +165,7 @@ class OperationQueryParameter
      *
      * @return void
      */
-    private function defineQueryParametersFromAnnotations(): void
+    private function defineFromAnnotations(): void
     {
         $swagQueries = array_filter($this->annotations, function ($annotation) {
             return $annotation instanceof SwagQuery;

--- a/tests/TestCase/Lib/Operation/OperationQueryParameterTest.php
+++ b/tests/TestCase/Lib/Operation/OperationQueryParameterTest.php
@@ -89,4 +89,26 @@ class OperationQueryParameterTest extends TestCase
         $parameter = $operation->getParameterByTypeAndName('query', 'sort');
         $this->assertEquals($enums, $parameter->getSchema()->getEnum());
     }
+
+    /**
+     * Tests Swag(ref="") parameters
+     */
+    public function testRefParameter()
+    {
+        $ref = '#/x-swagger-bake/components/parameters/paginatorPage';
+        $operationQueryParam = new OperationQueryParameter(
+            (new Operation())->setHttpMethod('GET'),
+            [
+                new SwagQuery(['ref'=> $ref]),
+            ],
+            new Controller()
+        );
+
+        $operation = $operationQueryParam->getOperationWithQueryParameters();
+        $key = 'x-swagger-bake-components-parameters-paginatorPage';
+        $parameter = $operation->getParameterByTypeAndName('query', $key);
+
+        $this->assertInstanceOf(Parameter::class, $parameter);
+        $this->assertEquals($ref, $parameter->getRef());
+    }
 }

--- a/tests/test_app/config/swagger-bare-bones.yml
+++ b/tests/test_app/config/swagger-bare-bones.yml
@@ -11,3 +11,30 @@ components:
     BearerAuth:
       type: http
       scheme: bearer
+x-swagger-bake:
+  components:
+    parameters:
+      paginatorPage:
+        name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+      paginatorLimit:
+        name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+      paginatorSort:
+        name: direction
+        in: query
+        required: false
+        schema:
+          type: string
+      paginatorDirection:
+        name: direction
+        in: query
+        required: false
+        schema:
+          type: string


### PR DESCRIPTION
Supported in SwagQuery and SwagHeader. Updated unit tests and readme.