### PR TITLE
Fixes bug with using SwaggerBake.beforeRender #202

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -6,33 +6,39 @@ extended functionality within your own project using the event system.
 
 ## Supported Events
 
-The `SwaggerBake.Operation.created` is dispatched each time a new Operation is
+The `SwaggerBake.Operation.created` is dispatched each time a new [Operation](src/Lib/OpenApi/Operation.php) is 
 created. Simply listen for the event: 
 
 ```php
 EventManager::instance()
     ->on('SwaggerBake.Operation.created', function (Event $event) {
-        // your code
+        /** @var \SwaggerBake\Lib\OpenApi\Operation $operation */
+        $operation = $event->getSubject();
     });
 ```
 
-The `SwaggerBake.Schema.created` is dispatched each time a new Schema is
+The `SwaggerBake.Schema.created` is dispatched each time a new [Schema](src/Lib/OpenApi/Schema.php) instance is 
 created. Simply listen for the event: 
 
 ```php
 EventManager::instance()
     ->on('SwaggerBake.Schema.created', function (Event $event) {
-        // your code
+        /** @var \SwaggerBake\Lib\OpenApi\Schema $schema */
+        $schema = $event->getSubject();
     });
 ```
 
-The `SwaggerBake.beforeRender` is dispatched once, just before SwaggerBake converts 
-data to an OpenAPI array or json.
+The `SwaggerBake.beforeRender` is dispatched once, just before [Swagger](src/Lib/Swagger.php) converts data to an 
+OpenAPI array or json. 
 
 ```php
 EventManager::instance()
     ->on('SwaggerBake.beforeRender', function (Event $event) {
-        // your code
+        /** @var \SwaggerBake\Lib\Swagger $swagger */
+        $swagger = $event->getSubject();
+        $array = $swagger->getArray();
+        $array['title'] = 'A new title';
+        $swagger->setArray($array);
     });
 ```
 

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -17,14 +17,11 @@ use SwaggerBake\Lib\Schema\SchemaFactory;
 use SwaggerBake\Lib\Schema\SchemaFromYamlFactory;
 use Symfony\Component\Yaml\Yaml;
 
-/**
- * Class Swagger
- *
- * @package SwaggerBake\Lib
- */
 class Swagger
 {
     /**
+     * OpenAPI array
+     *
      * @var array
      */
     private $array = [];
@@ -74,10 +71,6 @@ class Swagger
      */
     public function getArray(): array
     {
-        EventManager::instance()->dispatch(
-            new Event('SwaggerBake.beforeRender', $this->array)
-        );
-
         foreach ($this->array['paths'] as $method => $paths) {
             foreach ($paths as $pathId => $path) {
                 if ($path instanceof Path) {
@@ -111,12 +104,27 @@ class Swagger
     }
 
     /**
+     * @param array $array openapi array
+     * @return $this
+     */
+    public function setArray(array $array)
+    {
+        $this->array = $array;
+
+        return $this;
+    }
+
+    /**
      * Returns OpenAPI 3.0 spec as a JSON string
      *
      * @return false|string
      */
     public function toString()
     {
+        EventManager::instance()->dispatch(
+            new Event('SwaggerBake.beforeRender', $this)
+        );
+
         return json_encode($this->getArray(), JSON_PRETTY_PRINT);
     }
 


### PR DESCRIPTION
Moves event trigger into toString and provides setArray. Adds better examples to readme.