### PR TITLE
Adds support for a Generic Collection

### DIFF
--- a/assets/swagger.yml
+++ b/assets/swagger.yml
@@ -37,3 +37,42 @@ components:
           type: boolean
       xml:
         name: response
+x-swagger-bake:
+  components:
+    schemas:
+      Generic-Collection:
+        type: object
+        x-data-element: data
+        properties:
+          collection:
+            type: object
+            properties:
+              url:
+                type: string
+                format: url
+                example: /index
+              count:
+                type: integer
+                example: 20
+              total:
+                type: integer
+                example: 200
+              pages:
+                type: integer
+                example: 10
+              next:
+                type: string
+                format: url
+                example: /index?page=:number
+              prev:
+                type: string
+                format: url
+                example: /index?page=:number
+              first:
+                type: string
+                format: url
+                example: /index
+              last:
+                type: string
+                format: url
+                example: /index?page=:number

--- a/assets/x-swagger-bake.yaml
+++ b/assets/x-swagger-bake.yaml
@@ -62,33 +62,33 @@ x-swagger-bake:
                   href:
                     type: string
                     format: url
-                    example: /collection?page=:id
+                    example: /collection?page=:number
               prev:
                 type: object
                 properties:
                   href:
                     type: string
                     format: url
-                    example: /collection?page=:id
+                    example: /collection?page=:number
               first:
                 type: object
                 properties:
                   href:
                     type: string
                     format: url
-                    example: /collection?page=:id
+                    example: /collection?page=:number
               properties:
                 href:
                   type: string
                   format: url
-                  example: /collection?page=:id
+                  example: /collection?page=:number
             last:
               type: object
               properties:
                 href:
                   type: string
                   format: url
-                  example: /collection?page=:id
+                  example: /collection?page=:number
       JsonLd-Item:
         type: object
         properties:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -57,8 +57,7 @@ EventManager::instance()
 ## Custom Collection Schemas
 
 You can modify the schema of your `application/json` or `application/xml` collection responses with a custom collection 
-schema. Modify your base OpenAPI YAML file to include `#/x-swagger-bake/components/schemas/Generic-Collection`. 
-Example:
+schema. Modify your base OpenAPI YAML file to include `#/x-swagger-bake/components/schemas/Generic-Collection`. Example:
 
 ```
 x-swagger-bake:
@@ -101,6 +100,9 @@ x-swagger-bake:
                 format: url
                 example: /index?page=:number
 ```
+
+You would need to implement the sample schema in our application still. See 
+[MixerApi/CollectionView](https://github.com/mixerapi/collection-view) for a ready-made implementation.
 
 ## Adding your Extension to the SwaggerBake project
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,8 +1,6 @@
 # SwaggerBake Extensions
 
-Extensions to SwaggerBake can be added through the use of events. See CakeSearch 
-for an example. You may submit extensions as PRs to this project or simply create 
-extended functionality within your own project using the event system.
+Extensions to SwaggerBake can be added through the use of events and OpenAPI vendor extensions.
 
 ## Supported Events
 
@@ -28,6 +26,20 @@ EventManager::instance()
     });
 ```
 
+The `SwaggerBake.initialize` is dispatched once, just before [Swagger](src/Lib/Swagger.php) begins building OpenAPI 
+from your routes, models, and annotations.
+
+```php
+EventManager::instance()
+    ->on('SwaggerBake.initialize', function (Event $event) {
+        /** @var \SwaggerBake\Lib\Swagger $swagger */
+        $swagger = $event->getSubject();
+        $array = $swagger->getArray();
+        $array['title'] = 'A new title';
+        $swagger->setArray($array);
+    });
+```
+
 The `SwaggerBake.beforeRender` is dispatched once, just before [Swagger](src/Lib/Swagger.php) converts data to an 
 OpenAPI array or json. 
 
@@ -42,7 +54,57 @@ EventManager::instance()
     });
 ```
 
+## Custom Collection Schemas
+
+You can modify the schema of your `application/json` or `application/xml` collection responses with a custom collection 
+schema. Modify your base OpenAPI YAML file to include `#/x-swagger-bake/components/schemas/Generic-Collection`. 
+Example:
+
+```
+x-swagger-bake:
+  components:
+    schemas:
+      Generic-Collection:
+        type: object
+        x-data-element: data # property or node that contains the collections items (records)
+        properties:
+          collection: # sample of a property holding pagination data
+            type: object
+            properties:
+              url:
+                type: string
+                format: url
+                example: /index
+              count:
+                type: integer
+                example: 20
+              total:
+                type: integer
+                example: 200
+              pages:
+                type: integer
+                example: 10
+              next:
+                type: string
+                format: url
+                example: /index?page=:number
+              prev:
+                type: string
+                format: url
+                example: /index?page=:number
+              first:
+                type: string
+                format: url
+                example: /index
+              last:
+                type: string
+                format: url
+                example: /index?page=:number
+```
+
 ## Adding your Extension to the SwaggerBake project
+
+See CakeSearch for an example. You may submit extensions as PRs to this project.
 
 1. Your extension must implement ExtensionInterface. Read the interfaces comments and refer to the CakeSearch 
 extension for additional insight.

--- a/src/Lib/MediaType/Generic.php
+++ b/src/Lib/MediaType/Generic.php
@@ -9,6 +9,8 @@ use SwaggerBake\Lib\Swagger;
 
 class Generic
 {
+    use GenericTrait;
+
     /**
      * @var \SwaggerBake\Lib\OpenApi\Schema
      */
@@ -57,19 +59,13 @@ class Generic
                 ->setItems(['$ref' => $this->schema->getReadSchemaRef()]);
         }
 
-        if (isset($openapi['x-swagger-bake']['components']['schemas']['Generic-Collection']['x-data-element'])) {
-            $data = $openapi['x-swagger-bake']['components']['schemas']['Generic-Collection']['x-data-element'];
-        } else {
-            $data = 'data';
-        }
-
         return (new Schema())
             ->setAllOf([
                 ['$ref' => '#/x-swagger-bake/components/schemas/Generic-Collection'],
             ])
             ->setProperties([
                 (new SchemaProperty())
-                    ->setName($data)
+                    ->setName($this->whichData($openapi))
                     ->setType('array')
                     ->setItems([
                         'type' => 'object',

--- a/src/Lib/MediaType/GenericTrait.php
+++ b/src/Lib/MediaType/GenericTrait.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace SwaggerBake\Lib\MediaType;
+
+use SwaggerBake\Lib\OpenApi\Schema;
+
+trait GenericTrait
+{
+    /**
+     * Determines the name of the element that contains the collections items
+     *
+     * @param array $openapi openapi array
+     * @return string
+     */
+    private function whichData(array $openapi): string
+    {
+        if (!isset($openapi['x-swagger-bake']['components']['schemas']['Generic-Collection'])) {
+            return 'data';
+        }
+
+        if ($openapi['x-swagger-bake']['components']['schemas']['Generic-Collection'] instanceof Schema) {
+            /** @var \SwaggerBake\Lib\OpenApi\Schema $schema */
+            $schema = $openapi['x-swagger-bake']['components']['schemas']['Generic-Collection'];
+            $array = $schema->toArray();
+
+            return $array['x-data-element'] ?? 'data';
+        }
+
+        if (is_array($openapi['x-swagger-bake']['components']['schemas']['Generic-Collection'])) {
+            return $openapi['x-swagger-bake']['components']['schemas']['Generic-Collection']['x-data-element'];
+        }
+
+        return 'data';
+    }
+}

--- a/src/Lib/MediaType/Xml.php
+++ b/src/Lib/MediaType/Xml.php
@@ -9,6 +9,8 @@ use SwaggerBake\Lib\Swagger;
 
 class Xml
 {
+    use GenericTrait;
+
     /**
      * @var \SwaggerBake\Lib\OpenApi\Schema
      */
@@ -60,20 +62,6 @@ class Xml
                 ->setProperties([]);
         }
 
-        $dataElements = array_filter(
-            array_keys($openapi['x-swagger-bake']['components']['schemas']['Generic-Collection']['properties']),
-            function ($property) {
-                return strstr('x-data-', $property);
-            }
-        );
-
-        if (count($dataElements) === 1) {
-            $dataElement = reset($dataElements);
-            $data = str_replace('x-data-', '', $dataElement);
-        } else {
-            $data = 'data';
-        }
-
         return (new Schema())
             ->setAllOf([
                 ['$ref' => '#/x-swagger-bake/components/schemas/Generic-Collection'],
@@ -81,7 +69,7 @@ class Xml
             ->setXml((new \SwaggerBake\Lib\OpenApi\Xml())->setName('response'))
             ->setProperties([
                 (new SchemaProperty())
-                    ->setName($data)
+                    ->setName($this->whichData($openapi))
                     ->setType('array')
                     ->setItems([
                         'type' => 'object',

--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -142,6 +142,20 @@ class Schema implements JsonSerializable
     }
 
     /**
+     * Defines a vendor property, such as `x-my-property`
+     *
+     * @param string $name name of the attribute
+     * @param mixed $value value
+     * @return $this
+     */
+    public function setVendorProperty(string $name, $value)
+    {
+        $this->{$name} = $value;
+
+        return $this;
+    }
+
+    /**
      * @return string
      */
     public function getName(): string

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -88,8 +88,15 @@ class OperationFromRouteFactory
         $operation = (new OperationRequestBody($this->swagger, $operation, $annotations, $route, $schema))
             ->getOperationWithRequestBody();
 
-        $operation = (new OperationResponse($config, $operation, $docBlock, $annotations, $route, $schema))
-            ->getOperationWithResponses();
+        $operation = (new OperationResponse(
+            $this->swagger,
+            $config,
+            $operation,
+            $docBlock,
+            $annotations,
+            $route,
+            $schema
+        ))->getOperationWithResponses();
 
         EventManager::instance()->dispatch(
             new Event('SwaggerBake.Operation.created', $operation, [

--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -16,6 +16,7 @@ use SwaggerBake\Lib\OpenApi\Response;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\Xml;
 use SwaggerBake\Lib\Route\RouteDecorator;
+use SwaggerBake\Lib\Swagger;
 
 /**
  * Class OperationResponse
@@ -24,6 +25,11 @@ use SwaggerBake\Lib\Route\RouteDecorator;
  */
 class OperationResponse
 {
+    /**
+     * @var \SwaggerBake\Lib\Swagger
+     */
+    private $swagger;
+
     /**
      * @var \SwaggerBake\Lib\Configuration
      */
@@ -40,14 +46,14 @@ class OperationResponse
     private $doc;
 
     /**
-     * @var \SwaggerBake\Lib\Route\RouteDecorator
-     */
-    private $route;
-
-    /**
      * @var array
      */
     private $annotations;
+
+    /**
+     * @var \SwaggerBake\Lib\Route\RouteDecorator
+     */
+    private $route;
 
     /**
      * @var \SwaggerBake\Lib\OpenApi\Schema|null
@@ -55,6 +61,7 @@ class OperationResponse
     private $schema;
 
     /**
+     * @param \SwaggerBake\Lib\Swagger $swagger Swagger
      * @param \SwaggerBake\Lib\Configuration $config Configuration
      * @param \SwaggerBake\Lib\OpenApi\Operation $operation Operation
      * @param \phpDocumentor\Reflection\DocBlock $doc DocBlock
@@ -63,6 +70,7 @@ class OperationResponse
      * @param \SwaggerBake\Lib\OpenApi\Schema|null $schema Schema
      */
     public function __construct(
+        Swagger $swagger,
         Configuration $config,
         Operation $operation,
         DocBlock $doc,
@@ -70,6 +78,7 @@ class OperationResponse
         RouteDecorator $route,
         ?Schema $schema
     ) {
+        $this->swagger = $swagger;
         $this->config = $config;
         $this->operation = $operation;
         $this->doc = $doc;
@@ -205,7 +214,7 @@ class OperationResponse
 
         switch ($mimeType) {
             case 'application/xml':
-                return (new XmlMedia($schema))->buildSchema($action);
+                return (new XmlMedia($schema, $this->swagger))->buildSchema($action);
             case 'application/hal+json':
             case 'application/vnd.hal+json':
                 return (new HalJson($schema))->buildSchema($action);
@@ -215,7 +224,7 @@ class OperationResponse
                 return (new Schema())->setType('string');
         }
 
-        return (new Generic($schema))->buildSchema($action);
+        return (new Generic($schema, $this->swagger))->buildSchema($action);
     }
 
     /**

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -26,6 +26,11 @@ use Symfony\Component\Yaml\Yaml;
 class Swagger
 {
     /**
+     * @var string
+     */
+    private const ASSETS = __DIR__ . DS . '..' . DS . '..' . DS . 'assets' . DS;
+
+    /**
      * OpenAPI array
      *
      * @var array
@@ -61,9 +66,11 @@ class Swagger
         $this->buildSchemaFromYml();
         $this->buildPathsFromYml();
 
-        $this->array = array_merge(
-            $this->array,
-            Yaml::parseFile(__DIR__ . DS . '..' . DS . '..' . DS . 'assets' . DS . 'x-swagger-bake.yaml')
+        $xSwaggerBake = Yaml::parseFile(self::ASSETS . 'x-swagger-bake.yaml');
+
+        $this->array['x-swagger-bake'] = array_merge_recursive(
+            $xSwaggerBake['x-swagger-bake'],
+            $this->array['x-swagger-bake'] ?? []
         );
 
         $this->buildSchemasFromModels();

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -66,6 +66,10 @@ class Swagger
         $this->buildSchemaFromYml();
         $this->buildPathsFromYml();
 
+        EventManager::instance()->dispatch(
+            new Event('SwaggerBake.initialize', $this)
+        );
+
         $xSwaggerBake = Yaml::parseFile(self::ASSETS . 'x-swagger-bake.yaml');
 
         $this->array['x-swagger-bake'] = array_merge_recursive(

--- a/tests/TestCase/Lib/Operation/OperationResponseTest.php
+++ b/tests/TestCase/Lib/Operation/OperationResponseTest.php
@@ -7,6 +7,7 @@ use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use phpDocumentor\Reflection\DocBlockFactory;
 use SwaggerBake\Lib\Annotation\SwagResponseSchema;
+use SwaggerBake\Lib\Factory\SwaggerFactory;
 use SwaggerBake\Lib\Route\RouteScanner;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\OpenApi\Operation;
@@ -94,6 +95,7 @@ class OperationResponseTest extends TestCase
         $route = $this->routes['employees:index'];
 
         $operationResponse = new OperationResponse(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
             DocBlockFactory::createInstance()->create('/** @throws Exception */'),
@@ -122,6 +124,7 @@ class OperationResponseTest extends TestCase
         ;
 
         $operationResponse = new OperationResponse(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
             DocBlockFactory::createInstance()->create('/**  */'),
@@ -140,6 +143,7 @@ class OperationResponseTest extends TestCase
         $route = $this->routes['employees:add'];
 
         $operationResponse = new OperationResponse(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
             DocBlockFactory::createInstance()->create('/**  */'),
@@ -163,6 +167,7 @@ class OperationResponseTest extends TestCase
         $route = $this->routes['employees:delete'];
 
         $operationResponse = new OperationResponse(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
             DocBlockFactory::createInstance()->create('/**  */'),
@@ -180,6 +185,7 @@ class OperationResponseTest extends TestCase
         $route = $this->routes['employees:noresponsedefined'];
 
         $operationResponse = new OperationResponse(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
             DocBlockFactory::createInstance()->create('/**  */'),
@@ -202,6 +208,7 @@ class OperationResponseTest extends TestCase
         $route = $this->routes['employees:index'];
 
         $operationResponse = new OperationResponse(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
             DocBlockFactory::createInstance()->create('/** */'),
@@ -226,6 +233,7 @@ class OperationResponseTest extends TestCase
         $route = $this->routes['employees:index'];
 
         $operationResponse = new OperationResponse(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
             DocBlockFactory::createInstance()->create('/** */'),
@@ -253,6 +261,7 @@ class OperationResponseTest extends TestCase
         $route = $this->routes['employees:textplain'];
 
         $operationResponse = new OperationResponse(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
             DocBlockFactory::createInstance()->create('/** */'),


### PR DESCRIPTION
Resolves #205

- Modifies MediaType/Generic and MediaType/XML to read in Generic-Collection for samples if defined.
- Modifies OperationResponse so it can access openapi array from Swagger as a dependency.
- Modifies Swagger to merge user-defined additions to x-swagger-bake vendor space
- Updates unit tests.

Refactors:

- Fixes sample schema for HalJson-Collection
- Moves shared logic between Generic and XML into Generic Trait
- Adds Schema::setVendorProperty for creating adhoc vendor attributes
- Adds SwaggerBake.initialize event
- Updates docs/extensions.md with new functionality