### PR TITLE
Cake 4.2 and PHP 8.0 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,16 +35,17 @@ jobs:
           composer validate
           composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Test (!7.4)
-        if: ${{ matrix.php-versions != '7.4' }}
+      - name: Test (7.3|7.4)
+        if: ${{ matrix.php-versions != '8.0' }}
         run: vendor/bin/phpunit
 
-      - name: Test + Coverage + Static Analysis (7.4)
-        if: ${{ matrix.php-versions == '7.4' }}
+      - name: Test + Coverage + Static Analysis (8.0 only)
+        if: ${{ matrix.php-versions == '8.0' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer analyze
+          echo ${{ matrix.php-versions }}
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
-          composer global require twinh/php-coveralls
+          composer global require php-coveralls/php-coveralls
           php-coveralls --coverage_clover=clover.xml -v

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -35,12 +35,12 @@ jobs:
           composer validate
           composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Test (7.3|7.4)
-        if: ${{ matrix.php-versions != '8.0' }}
+      - name: Test (7.3|8.0)
+        if: ${{ matrix.php-versions != '7.4' }}
         run: vendor/bin/phpunit
 
-      - name: Test + Coverage + Static Analysis (8.0 only)
-        if: ${{ matrix.php-versions == '8.0' }}
+      - name: Test + Coverage + Static Analysis (7.4 only)
+        if: ${{ matrix.php-versions == '7.4' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-18.04 ]
-        php-versions: [ '7.3', '7.4' ]
+        php-versions: ['7.3', '7.4', '8.0']
 
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
@@ -29,35 +29,22 @@ jobs:
       - name: PHP Version
         run: php -v
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
-        with:
-          path: vendor
-          key: ${{ matrix.php-versions }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ matrix.php-versions }}-php-
-
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: |
+          composer validate
+          composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Code Quality
-        if: ${{ matrix.php-versions }} == '7.4'
-        run: composer check
-
-      - name: PHP Unit
-        if: ${{ matrix.php-versions }} != '7.4'
+      - name: Test (!7.4)
+        if: ${{ matrix.php-versions != '7.4' }}
         run: vendor/bin/phpunit
 
-      - name: Upload coverage results to Coveralls
-        if: ${{ matrix.php-versions }} != '7.4'
+      - name: Test + Coverage + Static Analysis (7.4)
+        if: ${{ matrix.php-versions = '7.4' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          composer analze
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
           composer global require twinh/php-coveralls
           php-coveralls --coverage_clover=clover.xml -v

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,7 +40,7 @@ jobs:
         run: vendor/bin/phpunit
 
       - name: Test + Coverage + Static Analysis (7.4)
-        if: ${{ matrix.php-versions = '7.4' }}
+        if: ${{ matrix.php-versions == '7.4' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          composer analze
+          composer analyze
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
           composer global require twinh/php-coveralls
           php-coveralls --coverage_clover=clover.xml -v

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and controllers.
 
 SwaggerBake requires CakePHP4 and a few dependencies that will be automatically installed via composer.
 
-```
+```console
 composer require cnizzardini/cakephp-swagger-bake
 ```
 
@@ -426,12 +426,12 @@ local source to make developing easier:
 Undo these steps when you're done. Read the full composer documentation on loading from path here: 
 [https://getcomposer.org/doc/05-repositories.md#path](https://getcomposer.org/doc/05-repositories.md#path)
 
-## Coding Standards
+## Tests + Analysis
 
-Coding standards run as part of CI with Travis. You may run these locally with `composer check`.
+```console
+# unit tests only
+composer test
 
-## Unit Tests
-
-```sh
-vendor/bin/phpunit
+# unit tests and static analysis
+composer analyze
 ```

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "cakephp/cakephp": "~4.0",
+        "cakephp/cakephp": "^4.0",
         "symfony/yaml": "^5.0",
         "phpdocumentor/reflection-docblock": "^5.1",
         "doctrine/annotations": "^1.10",
@@ -40,17 +40,16 @@
         }
     },
     "scripts": {
-        "check": [
+        "analyze": [
             "@test",
-            "@cs-check",
-            "@stan",
-            "@md"
+            "@phpcs",
+            "@phpstan"
         ],
-        "cs-check": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/",
-        "cs-fix": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/",
-        "stan": "phpstan analyse src/",
+        "phpcs": "phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/",
+        "phpcbf": "phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP src/",
+        "phpstan": "phpstan analyse src/",
         "test": "phpunit --colors=always",
-        "md": "phpmd src/ ansi phpmd.xml",
+        "phpmd": "phpmd src/ ansi phpmd.xml",
         "coverage": "phpunit --coverage-html coverage-reports/"
     },
     "support": {

--- a/src/Lib/Configuration.php
+++ b/src/Lib/Configuration.php
@@ -59,7 +59,7 @@ class Configuration
                     'tables' => ['\App\\'],
                 ],
             ],
-            Configure::read('SwaggerBake')
+            Configure::read('SwaggerBake') ?? []
         );
     }
 

--- a/tests/TestCase/Lib/Utility/NamespaceUtilityTest.php
+++ b/tests/TestCase/Lib/Utility/NamespaceUtilityTest.php
@@ -27,12 +27,6 @@ class NamespaceUtilityTest extends TestCase
         $this->assertEquals('\SwaggerBakeTest\App\Model\Entity\Department', $fqns);
     }
 
-    public function testGetEntityFullyQualifiedNameSpaceException()
-    {
-        $this->expectException(SwaggerBakeRunTimeException::class);
-        NamespaceUtility::getEntityFullyQualifiedNameSpace('Department', new Configuration());
-    }
-
     public function testGetEntityFullyQualifiedNameSpaceNull()
     {
         $fqns = NamespaceUtility::getEntityFullyQualifiedNameSpace(
@@ -57,12 +51,6 @@ class NamespaceUtilityTest extends TestCase
             ])
         );
         $this->assertEquals('\SwaggerBakeTest\App\Model\Table\DepartmentsTable', $fqns);
-    }
-
-    public function testGetTableFullyQualifiedNameSpaceException()
-    {
-        $this->expectException(SwaggerBakeRunTimeException::class);
-        NamespaceUtility::getTableFullyQualifiedNameSpace('DepartmentsTable', new Configuration());
     }
 
     public function testGetTableFullyQualifiedNameSpaceNull()


### PR DESCRIPTION
Resolves #227

- Adds PHP 8.0 to builds
- Disables PHPMD until it supports PHP 8.0
- Resolves changes in CakePHP exceptions