### PR TITLE
Allow override json_encode options from swagger_bake config

### DIFF
--- a/assets/swagger_bake.php
+++ b/assets/swagger_bake.php
@@ -24,6 +24,10 @@
  * # OPTIONAL SETTINGS:
  * ################################
  *
+ * @var int $jsonOptions: A bitmask of options passed as second parameter to json_encode function. Accepted values are
+ *      described at https://www.php.net/manual/en/function.json-encode.php
+ *      Default: JSON_PRETTY_PRINT
+ *
  * @var string[] $requestAccepts: Array of mime types accepted. Can be used if your application accepts JSON, XML etc...
  *      Default: application/x-www-form-urlencoded
  *
@@ -50,6 +54,7 @@ return [
         'hotReload' => \Cake\Core\Configure::read('debug'),
         /** optional configurations below:  **/
         /*
+        'jsonOptions' => JSON_PRETTY_PRINT,
         'requestAccepts' => [
             'application/x-www-form-urlencoded',
             'application/json',
@@ -65,7 +70,7 @@ return [
             'controllers' => ['\App\\'],
             'entities' => ['\App\\'],
             'tables' => ['\App\\']
-        ]
+        ],
         */
     ]
 ];

--- a/src/Lib/Configuration.php
+++ b/src/Lib/Configuration.php
@@ -33,32 +33,35 @@ class Configuration
     {
         $this->root = $root;
 
+        $defaultConfig = [
+            'docType' => 'swagger',
+            'hotReload' => false,
+            'exceptionSchema' => 'Exception',
+            'requestAccepts' => [
+                'application/x-www-form-urlencoded',
+                'application/json',
+                'application/xml',
+            ],
+            'responseContentTypes' => [
+                'application/json',
+                'application/xml',
+            ],
+            'namespaces' => [
+                'controllers' => ['\App\\'],
+                'entities' => ['\App\\'],
+                'tables' => ['\App\\'],
+            ],
+            'jsonOptions' => JSON_PRETTY_PRINT,
+        ];
+
         if (!empty($config)) {
-            $this->configs = $config;
+            $this->configs = $config + $defaultConfig;
 
             return;
         }
 
         $this->configs = array_merge(
-            [
-                'docType' => 'swagger',
-                'hotReload' => false,
-                'exceptionSchema' => 'Exception',
-                'requestAccepts' => [
-                    'application/x-www-form-urlencoded',
-                    'application/json',
-                    'application/xml',
-                ],
-                'responseContentTypes' => [
-                    'application/json',
-                    'application/xml',
-                ],
-                'namespaces' => [
-                    'controllers' => ['\App\\'],
-                    'entities' => ['\App\\'],
-                    'tables' => ['\App\\'],
-                ],
-            ],
+            $defaultConfig,
             Configure::read('SwaggerBake') ?? []
         );
     }

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -143,7 +143,7 @@ class Swagger
             new Event('SwaggerBake.beforeRender', $this)
         );
 
-        return json_encode($this->getArray(), JSON_PRETTY_PRINT);
+        return json_encode($this->getArray(), $this->config->get('jsonOptions'));
     }
 
     /**

--- a/tests/TestCase/Lib/SwaggerTest.php
+++ b/tests/TestCase/Lib/SwaggerTest.php
@@ -77,6 +77,10 @@ class SwaggerTest extends TestCase
 
         $swagger = new Swagger(new ModelScanner($cakeRoute, $config));
 
+        $jsonString = $swagger->toString();
+        $this->assertStringContainsString('"\/departments"', $jsonString);
+        $this->assertStringContainsString("\n", $jsonString);
+
         $arr = json_decode($swagger->toString(), true);
 
         $this->assertArrayHasKey('/pets', $arr['paths']);
@@ -96,5 +100,26 @@ class SwaggerTest extends TestCase
 
         $this->assertArrayHasKey('/departments', $arr['paths']);
         $this->assertArrayHasKey('Department', $arr['components']['schemas']);
+    }
+
+    public function testCustomJsonOptions()
+    {
+        $vars = $this->config;
+        $vars['jsonOptions'] = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+        $config = new Configuration($vars, SWAGGER_BAKE_TEST_APP);
+
+        $cakeRoute = new RouteScanner($this->router, $config);
+
+        $swagger = new Swagger(new ModelScanner($cakeRoute, $config));
+        $jsonString = $swagger->toString();
+
+        $this->assertStringNotContainsString('"\/departments"', $jsonString);
+        $this->assertStringContainsString('"/departments"', $jsonString);
+        $this->assertStringNotContainsString("\n", $jsonString);
+
+        $arr = json_decode($swagger->toString(), true);
+
+        $this->assertArrayHasKey('/pets', $arr['paths']);
+        $this->assertArrayHasKey('Pets', $arr['components']['schemas']);
     }
 }


### PR DESCRIPTION
Also, to keep the new `jsonOptions` optional and don't break BC, I applied default $config also into directed injected array on `Configuration::__construct`.