### PR TITLE
Support/improve verbose descriptions for schema properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,23 @@ code. You must use the FQN for exceptions.
 public function index() {}
 ```
 
+For Entities, the description from `@property` is supported:
+
+```php
+/**
+ * City Entity
+ *
+ * @property string $name Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+ * incididunt ut labore et dolore magna aliqua. 
+ *
+ * - some
+ * - bullets
+ *
+ * Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+ * magna aliqua.
+ */
+```
+
 ## Annotations
 
 SwaggerBake provides some optional Annotations for enhanced functionality. These can be imported individually from 
@@ -286,7 +303,8 @@ bin/cake bake controller {Name} --theme SwaggerBake
     - Writeable properties `#/x-swagger-bake/components/schemas/Entity-Write`
     - Readable properties `#/x-swagger-bake/components/schemas/Entity-Read`
 - Entity Attributes: 
-  - Hidden attributes will not be visible
+  - Reads descriptions from `@property` doc block tags.
+  - Hidden attributes will not be visible.
   - Primary Keys will be set to read only by default.
   - DateTime fields named `created` and `modified` are automatically set to read only per Cake convention.
 - CRUD Responses

--- a/src/Lib/Schema/SchemaFactory.php
+++ b/src/Lib/Schema/SchemaFactory.php
@@ -19,11 +19,9 @@ use SwaggerBake\Lib\OpenApi\SchemaProperty;
 use SwaggerBake\Lib\Utility\AnnotationUtility;
 
 /**
- * Class SchemaFactory
- *
- * @package SwaggerBake\Lib\Factory
- *
  * Creates an instance of SwaggerBake\Lib\OpenApi\Schema per OpenAPI specifications
+ *
+ * @internal
  */
 class SchemaFactory
 {
@@ -68,7 +66,7 @@ class SchemaFactory
 
         $docBlock = $this->getDocBlock($model->getEntity());
 
-        $properties = $this->getProperties($model, $propertyType);
+        $properties = $this->getProperties($model, $propertyType, $docBlock);
 
         $schema = (new Schema())
             ->setName((new ReflectionClass($model->getEntity()))->getShortName())
@@ -101,12 +99,13 @@ class SchemaFactory
     /**
      * @param \MixerApi\Core\Model\Model $model Model
      * @param int $propertyType see public constants for options
+     * @param \phpDocumentor\Reflection\DocBlock|null $docBlock DocBlock instance
      * @return array
      */
-    private function getProperties(Model $model, int $propertyType): array
+    private function getProperties(Model $model, int $propertyType, ?DocBlock $docBlock): array
     {
         $return = [];
-        $factory = new SchemaPropertyFactory($this->validator);
+        $factory = new SchemaPropertyFactory($this->validator, $docBlock);
 
         foreach ($model->getProperties() as $property) {
             $return[$property->getName()] = $factory->create($property);

--- a/tests/TestCase/Lib/Schema/SchemaFactoryTest.php
+++ b/tests/TestCase/Lib/Schema/SchemaFactoryTest.php
@@ -10,6 +10,7 @@ use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\Decorator\EntityDecorator;
 use SwaggerBake\Lib\Model\ModelDecorator;
 use SwaggerBake\Lib\OpenApi\Schema;
+use SwaggerBake\Lib\OpenApi\SchemaProperty;
 use SwaggerBake\Lib\Schema\SchemaFactory;
 use SwaggerBakeTest\App\Model\Entity\Department;
 use SwaggerBakeTest\App\Model\Table\DepartmentsTable;
@@ -41,16 +42,20 @@ class SchemaFactoryTest extends TestCase
         ], SWAGGER_BAKE_TEST_APP);
     }
 
-    public function testCreateSchema()
+    public function test_create_schema()
     {
         $connection = ConnectionManager::get('default');
         $department = (new ModelFactory($connection, new DepartmentsTable()))->create();
         $decorator = new ModelDecorator($department, new Controller());
         $schema = (new SchemaFactory())->create($decorator);
         $this->assertInstanceOf(Schema::class, $schema);
+
+        /** @var SchemaProperty[] $properties */
+        $properties = $schema->getProperties();
+        $this->assertEquals('this_is_a_unit_test_for_description', $properties['name']->getDescription());
     }
 
-    public function testWriteSchema()
+    public function test_write_schema()
     {
         $connection = ConnectionManager::get('default');
         $department = (new ModelFactory($connection, new DepartmentsTable()))->create();

--- a/tests/test_app/src/Model/Entity/Department.php
+++ b/tests/test_app/src/Model/Entity/Department.php
@@ -9,7 +9,7 @@ use Cake\ORM\Entity;
  * Department Entity
  *
  * @property int $id
- * @property string $name
+ * @property string $name this_is_a_unit_test_for_description
  *
  * @property \SwaggerBake\Test\Model\Entity\DepartmentEmployee[] $department_employees
  */


### PR DESCRIPTION
Resolves #237

Adds support for Entity `@property` tag descriptions.