### PR TITLE
Refactors OperationResponse, SwagResponseSchema, and MediaTypes

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -528,18 +528,22 @@ Method level annotation for defining response schema.
 
 | Attribute | Type / Default | Description | 
 | ------------- | ------------- | ------------- |
-| refEntity | string `""` | The OpenAPI entity |
-| statusCode | string `200` | Response code |
-| mimeTypes | array `[]` | An array of mime types the response can be |
-| description | string `null` | Description of the response |
-| schemaType | string `null` |  |
-| schemaFormat | string `null` |  |
-| schemaItems | array `[]` |  |
-
+| refEntity | string `` | The OpenAPI entity (e.g. `"#/components/schemas/ModelName"` |
+| statusCode | string `200` | The HTTP response code |
+| mimeTypes | array `null` | An array of mime types the response can, if null settings from swagger_bake config are used. |
+| description | string `` | Description of the response |
+| schemaType | string `` | The schema response type, generally `"object"` or `"array"` |
+| schemaFormat | string `` | The schema format, generally only used for schemaType of string. |
+| ~~schemaItems~~ | removed | This was removed in v2.0 |
 
 ```php
 /**
- * @Swag\SwagResponseSchema(refEntity="#/components/schemas/Actor", description="Summary", statusCode="200")
+ * @Swag\SwagResponseSchema(
+ *     schemaType="object", 
+ *     refEntity="#/components/schemas/Actor", 
+ *     description="Summary", 
+ *     statusCode="200"
+ * )
  */
 public function view() {}
 ```
@@ -561,7 +565,12 @@ Defining a single mimeType and 400-409 status code range:
 
 ```php
 /**
- * @Swag\SwagResponseSchema(refEntity="#/components/schemas/Exception", mimeTypes={"application/xml"}, statusCode="40x")
+ * @Swag\SwagResponseSchema(
+ *     schemaType="object", 
+ *     refEntity="#/components/schemas/Exception",
+ *     mimeTypes={"application/xml","application/json"}, 
+ *     statusCode="40x"
+ * )
  */
 ```
 
@@ -581,7 +590,10 @@ Defining an array of objects:
 
 ```php
 /**
- * @Swag\SwagResponseSchema(schemaItems={"$ref"="#/components/schemas/Actor"})
+ * @Swag\SwagResponseSchema(
+ *     schemaType="array", 
+ *     refEntity="#/components/schemas/Actor"
+ * )
  */
 ```
 

--- a/src/Lib/Annotation/SwagResponseSchema.php
+++ b/src/Lib/Annotation/SwagResponseSchema.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Lib\Annotation;
 
-use Cake\Log\Log;
-
 /**
  * Method level annotation for defining custom response schema for OpenApi response content.
  *
@@ -12,18 +10,14 @@ use Cake\Log\Log;
  * @Target({"METHOD"})
  * @Attributes({
  * @Attribute("refEntity", type = "string"),
- * @Attribute("httpCode", type = "integer"),
  * @Attribute("statusCode", type = "string"),
  * @Attribute("description", type = "string"),
- * @Attribute("mimeType", type = "string"),
  * @Attribute("mimeTypes", type = "array"),
  * @Attribute("schemaType", type = "string"),
  * @Attribute("schemaFormat", type = "string"),
- * @Attribute("schemaItems", type = "array")
  * })
  * @see https://swagger.io/docs/specification/describing-responses/
  * @see https://swagger.io/specification/
- * @todo remove httpCode in future version
  */
 class SwagResponseSchema
 {
@@ -36,12 +30,11 @@ class SwagResponseSchema
     public $refEntity;
 
     /**
-     * Response HTTP Status Code such as 200, 40x, or 5xx
+     * The http status code, can be alphanumeric (e.g. 200, 20x, 4xx)
      *
      * @var string
-     * @example 200
      */
-    public $httpCode = '200';
+    public $statusCode;
 
     /**
      * Response Schema description
@@ -49,15 +42,6 @@ class SwagResponseSchema
      * @var string
      */
     public $description;
-
-    /**
-     * Response Content mime type
-     *
-     * @var string
-     * @example application/json
-     * @deprecated use $mimeTypes
-     */
-    public $mimeType;
 
     /**
      * Response Content mime types
@@ -68,7 +52,7 @@ class SwagResponseSchema
     public $mimeTypes;
 
     /**
-     * The data type of the schema
+     * The data type of the response schema, generally object or array
      *
      * @var string
      * @example object
@@ -78,7 +62,7 @@ class SwagResponseSchema
     public $schemaType;
 
     /**
-     * The date format of the schema
+     * The date format of the schema, not generally applicable for object or array schemaType's
      *
      * @var string
      * @example date-time
@@ -87,62 +71,15 @@ class SwagResponseSchema
     public $schemaFormat;
 
     /**
-     * Key-value pair for schema items
-     *
-     * @var array
-     */
-    public $schemaItems = [];
-
-    /**
-     * Default values
-     *
-     * @var array
-     */
-    private const DEFAULTS = [
-        'refEntity' => '',
-        'httpCode' => '200',
-        'statusCode' => '200',
-        'description' => '',
-        'mimeType' => '',
-        'mimeTypes' => [],
-        'schemaType' => '',
-        'schemaFormat' => '',
-        'schemaItems' => [],
-    ];
-
-    /**
      * @param array $values Annotation attributes as key-value pair
      */
     public function __construct(array $values)
     {
-        if (isset($values['httpCode'])) {
-            $this->httpCode = (string)$values['httpCode'];
-            $msg = 'SwaggerBake: `httpCode` is deprecated, use `statusCode` in SwagResponseSchema';
-            Log::warning($msg);
-            deprecationWarning($msg);
-        }
-
-        if (isset($values['mimeType'])) {
-            // @codeCoverageIgnoreStart
-            $values['mimeTypes'] = $values['mimeTypes'] ?? [];
-            array_push($values['mimeTypes'], $values['mimeType']);
-            $msg = 'SwaggerBake: `mimeType` is deprecated, use `mimeTypes` in SwagResponseSchema';
-            Log::warning($msg);
-            deprecationWarning($msg);
-            // @codeCoverageIgnoreEnd
-        }
-
-        if (isset($values['statusCode'])) {
-            $this->httpCode = $values['statusCode'];
-        }
-
-        $values = array_merge(self::DEFAULTS, $values);
-
-        $this->refEntity = $values['refEntity'];
-        $this->description = $values['description'];
+        $this->statusCode = $values['statusCode'] ?? '200';
+        $this->refEntity = $values['refEntity'] ?? '';
+        $this->description = $values['description'] ?? '';
         $this->mimeTypes = $values['mimeTypes'];
-        $this->schemaType = $values['schemaType'];
-        $this->schemaFormat = $values['schemaFormat'];
-        $this->schemaItems = $values['schemaItems'];
+        $this->schemaType = $values['schemaType'] ?? '';
+        $this->schemaFormat = $values['schemaFormat'] ?? '';
     }
 }

--- a/src/Lib/MediaType/AbstractMediaType.php
+++ b/src/Lib/MediaType/AbstractMediaType.php
@@ -5,10 +5,14 @@ namespace SwaggerBake\Lib\MediaType;
 
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\Swagger;
-use SwaggerBake\Lib\Utility\SchemaRefUtility;
 
 abstract class AbstractMediaType
 {
+    /**
+     * @var \SwaggerBake\Lib\OpenApi\Schema|string
+     */
+    protected $schema;
+
     /**
      * @var \SwaggerBake\Lib\Swagger
      */
@@ -30,8 +34,12 @@ abstract class AbstractMediaType
         $this->swagger = $swagger;
 
         if ($schema instanceof Schema) {
-            $this->ref = SchemaRefUtility::whichRef($schema, $swagger, $schema->getReadSchemaRef());
+            $read = $schema->getReadSchemaName();
+            $name = $schema->getName();
+            $this->schema = $swagger->getSchemaByName($read) ?? $swagger->getSchemaByName($name);
+            $this->ref = $this->schema->getRefPath();
         } elseif (is_string($schema)) {
+            $this->schema = $schema;
             $this->ref = $schema;
         } else {
             throw new \InvalidArgumentException(

--- a/src/Lib/MediaType/Generic.php
+++ b/src/Lib/MediaType/Generic.php
@@ -6,21 +6,20 @@ namespace SwaggerBake\Lib\MediaType;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
 
-class Generic extends AbstractMediaType
+class Generic extends AbstractMediaType implements MediaTypeInterface
 {
     /**
-     * Returns a generic schema
-     *
-     * @param string $action controller action (e.g. add, index, view, edit, delete)
-     * @return \SwaggerBake\Lib\OpenApi\Schema
+     * @inheritDoc
      */
-    public function buildSchema(string $action): Schema
+    public function buildSchema(string $schemaType): Schema
     {
-        if ($action == 'index') {
-            return $this->collection();
+        if (!in_array($schemaType, ['array', 'object'])) {
+            throw new \InvalidArgumentException(
+                "Argument must be array or object but was given schema type `$schemaType`"
+            );
         }
 
-        return $this->item();
+        return $schemaType === 'array' ? $this->collection() : $this->item();
     }
 
     /**

--- a/src/Lib/MediaType/HalJson.php
+++ b/src/Lib/MediaType/HalJson.php
@@ -6,7 +6,7 @@ namespace SwaggerBake\Lib\MediaType;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
 
-class HalJson extends AbstractMediaType
+class HalJson extends AbstractMediaType implements MediaTypeInterface
 {
     /**
      * @var string
@@ -19,24 +19,23 @@ class HalJson extends AbstractMediaType
     public const HAL_COLLECTION = '#/x-swagger-bake/components/schemas/HalJson-Collection';
 
     /**
-     * Returns HAL+JSON schema
-     *
-     * @param string $action controller action (e.g. add, index, view, edit, delete)
-     * @return \SwaggerBake\Lib\OpenApi\Schema
+     * @inheritDoc
      */
-    public function buildSchema(string $action): Schema
+    public function buildSchema(string $schemaType): Schema
     {
-        if ($action == 'index') {
-            return $this->collection();
+        if (!in_array($schemaType, ['array', 'object'])) {
+            throw new \InvalidArgumentException(
+                "Argument must be array or object but was given schema type `$schemaType`"
+            );
         }
 
-        return $this->item();
+        return $schemaType === 'array' ? $this->collection() : $this->item();
     }
 
     /**
      * @return \SwaggerBake\Lib\OpenApi\Schema
      */
-    private function collection(): Schema
+    protected function collection(): Schema
     {
         return (new Schema())
             ->setAllOf([

--- a/src/Lib/MediaType/JsonLd.php
+++ b/src/Lib/MediaType/JsonLd.php
@@ -6,7 +6,7 @@ namespace SwaggerBake\Lib\MediaType;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
 
-class JsonLd extends AbstractMediaType
+class JsonLd extends AbstractMediaType implements MediaTypeInterface
 {
     /**
      * @var string
@@ -19,18 +19,17 @@ class JsonLd extends AbstractMediaType
     public const JSONLD_COLLECTION = '#/x-swagger-bake/components/schemas/JsonLd-Collection';
 
     /**
-     * Returns JSON-LD schema
-     *
-     * @param string $action controller action (e.g. add, index, view, edit, delete)
-     * @return \SwaggerBake\Lib\OpenApi\Schema
+     * @inheritDoc
      */
-    public function buildSchema(string $action): Schema
+    public function buildSchema(string $schemaType): Schema
     {
-        if ($action == 'index') {
-            return $this->collection();
+        if (!in_array($schemaType, ['array', 'object'])) {
+            throw new \InvalidArgumentException(
+                "Argument must be array or object but was given schema type `$schemaType`"
+            );
         }
 
-        return $this->item();
+        return $schemaType === 'array' ? $this->collection() : $this->item();
     }
 
     /**

--- a/src/Lib/MediaType/MediaTypeInterface.php
+++ b/src/Lib/MediaType/MediaTypeInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace SwaggerBake\Lib\MediaType;
+
+use SwaggerBake\Lib\OpenApi\Schema;
+
+interface MediaTypeInterface
+{
+    /**
+     * Returns a response schema
+     *
+     * @param string $schemaType array or object
+     * @return \SwaggerBake\Lib\OpenApi\Schema
+     * @throws \InvalidArgumentException if $schemaType isn't array or object
+     */
+    public function buildSchema(string $schemaType): Schema;
+}

--- a/src/Lib/MediaType/Xml.php
+++ b/src/Lib/MediaType/Xml.php
@@ -6,21 +6,20 @@ namespace SwaggerBake\Lib\MediaType;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApi\SchemaProperty;
 
-class Xml extends AbstractMediaType
+class Xml extends AbstractMediaType implements MediaTypeInterface
 {
     /**
-     * Returns Xml schema
-     *
-     * @param string $action controller action (e.g. add, index, view, edit, delete)
-     * @return \SwaggerBake\Lib\OpenApi\Schema
+     * @inheritDoc
      */
-    public function buildSchema(string $action): Schema
+    public function buildSchema(string $schemaType): Schema
     {
-        if ($action == 'index') {
-            return $this->collection();
+        if (!in_array($schemaType, ['array', 'object'])) {
+            throw new \InvalidArgumentException(
+                "Argument must be array or object but was given schema type `$schemaType`"
+            );
         }
 
-        return $this->item();
+        return $schemaType === 'array' ? $this->collection() : $this->item();
     }
 
     /**

--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -17,11 +17,6 @@ class Schema implements JsonSerializable, SchemaInterface
     use SchemaTrait;
 
     /**
-     * @var string
-     */
-    public const SCHEMA = '#/x-swagger-bake/components/schemas/';
-
-    /**
      * @var string|null
      */
     private $title;
@@ -79,6 +74,13 @@ class Schema implements JsonSerializable, SchemaInterface
     private $isPublic = true;
 
     /**
+     * The openapi ref location (e.g. #/components/schemas/Model)
+     *
+     * @var string|null
+     */
+    private $refPath;
+
+    /**
      * @return array
      */
     public function toArray(): array
@@ -86,7 +88,7 @@ class Schema implements JsonSerializable, SchemaInterface
         $vars = get_object_vars($this);
 
         // always unset
-        foreach (['name','refEntity','isPublic'] as $v) {
+        foreach (['name','refEntity','isPublic', 'refPath'] as $v) {
             unset($vars[$v]);
         }
 
@@ -219,11 +221,11 @@ class Schema implements JsonSerializable, SchemaInterface
      */
     public function pushProperty(SchemaInterface $property)
     {
-        if (empty($property->getName())) {
-            throw new \LogicException(
-                'Name must be set on ' . get_class($property)
-            );
-        }
+        /*        if (empty($property->getName())) {
+                    throw new \LogicException(
+                        'Name must be set on ' . get_class($property)
+                    );
+                }*/
 
         $this->properties[$property->getName()] = $property;
 
@@ -402,38 +404,6 @@ class Schema implements JsonSerializable, SchemaInterface
     }
 
     /**
-     * @return string
-     */
-    public function getWriteSchemaRef(): string
-    {
-        return self::SCHEMA . $this->getWriteSchemaName();
-    }
-
-    /**
-     * @return string
-     */
-    public function getAddSchemaRef(): string
-    {
-        return self::SCHEMA . $this->getAddSchemaName();
-    }
-
-    /**
-     * @return string
-     */
-    public function getEditSchemaRef(): string
-    {
-        return self::SCHEMA . $this->getEditSchemaName();
-    }
-
-    /**
-     * @return string
-     */
-    public function getReadSchemaRef(): string
-    {
-        return self::SCHEMA . $this->getReadSchemaName();
-    }
-
-    /**
      * @return bool
      */
     public function isPublic(): bool
@@ -448,6 +418,25 @@ class Schema implements JsonSerializable, SchemaInterface
     public function setIsPublic(bool $isPublic)
     {
         $this->isPublic = $isPublic;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getRefPath(): ?string
+    {
+        return $this->refPath;
+    }
+
+    /**
+     * @param string $refPath the openapi ref location (e.g. #/components/schemas/Model)
+     * @return $this
+     */
+    public function setRefPath(string $refPath)
+    {
+        $this->refPath = $refPath;
 
         return $this;
     }

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -92,11 +92,12 @@ class OperationFromRouteFactory
             $this->swagger,
             $config,
             $operation,
-            $docBlock,
             $annotations,
             $route,
             $schema
         ))->getOperationWithResponses();
+
+        $operation = (new OperationResponseException($this->swagger, $config, $operation, $docBlock))->getOperation();
 
         EventManager::instance()->dispatch(
             new Event('SwaggerBake.Operation.created', $operation, [

--- a/src/Lib/Operation/OperationRequestBody.php
+++ b/src/Lib/Operation/OperationRequestBody.php
@@ -15,7 +15,6 @@ use SwaggerBake\Lib\OpenApi\SchemaProperty;
 use SwaggerBake\Lib\OpenApi\Xml;
 use SwaggerBake\Lib\Route\RouteDecorator;
 use SwaggerBake\Lib\Swagger;
-use SwaggerBake\Lib\Utility\SchemaRefUtility;
 
 /**
  * Class OperationRequestBody
@@ -281,13 +280,23 @@ class OperationRequestBody
 
             $content = (new Content())->setMimeType($mimeType);
 
-            if (in_array($this->operation->getHttpMethod(), ['POST'])) {
+            if (
+                in_array($this->operation->getHttpMethod(), ['POST'])
+                &&
+                $this->swagger->getSchemaByName($schema->getAddSchemaName())
+            ) {
                 $content->setSchema(
-                    SchemaRefUtility::whichRef($schema, $this->swagger, $this->schema->getAddSchemaRef())
+                    $this->swagger->getSchemaByName($schema->getAddSchemaName())->getRefPath()
                 );
-            } else {
+            } elseif ($this->swagger->getSchemaByName($schema->getEditSchemaName())) {
                 $content->setSchema(
-                    SchemaRefUtility::whichRef($schema, $this->swagger, $this->schema->getEditSchemaRef())
+                    $this->swagger->getSchemaByName($schema->getEditSchemaName())->getRefPath()
+                );
+            }
+
+            if ($content->getSchema() === null) {
+                $content->setSchema(
+                    $this->swagger->getSchemaByName($schema->getName())->getRefPath()
                 );
             }
 

--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Lib\Operation;
 
-use phpDocumentor\Reflection\DocBlock;
 use SwaggerBake\Lib\Annotation\SwagResponseSchema;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\MediaType\Generic;
@@ -64,7 +63,6 @@ class OperationResponse
      * @param \SwaggerBake\Lib\Swagger $swagger Swagger
      * @param \SwaggerBake\Lib\Configuration $config Configuration
      * @param \SwaggerBake\Lib\OpenApi\Operation $operation Operation
-     * @param \phpDocumentor\Reflection\DocBlock $doc DocBlock
      * @param array $annotations An array of annotation objects
      * @param \SwaggerBake\Lib\Route\RouteDecorator $route RouteDecorator
      * @param \SwaggerBake\Lib\OpenApi\Schema|null $schema Schema
@@ -73,7 +71,6 @@ class OperationResponse
         Swagger $swagger,
         Configuration $config,
         Operation $operation,
-        DocBlock $doc,
         array $annotations,
         RouteDecorator $route,
         ?Schema $schema
@@ -81,7 +78,6 @@ class OperationResponse
         $this->swagger = $swagger;
         $this->config = $config;
         $this->operation = $operation;
-        $this->doc = $doc;
         $this->annotations = $annotations;
         $this->route = $route;
         $this->schema = $schema;
@@ -94,126 +90,100 @@ class OperationResponse
      */
     public function getOperationWithResponses(): Operation
     {
-        $this->assignAnnotations();
-        $this->assignDocBlockExceptions();
-        $this->assignSchema();
+        $this->assignFromAnnotations();
+        $this->assignFromCrudActions();
         $this->assignDefaultResponses();
 
         return $this->operation;
     }
 
     /**
-     * Set Responses using SwagResponseSchema
+     * Set Responses using SwagResponseSchema annotation
      *
      * @return void
      */
-    private function assignAnnotations(): void
+    private function assignFromAnnotations(): void
     {
         $swagResponses = array_filter($this->annotations, function ($annotation) {
             return $annotation instanceof SwagResponseSchema;
         });
 
         foreach ($swagResponses as $annotate) {
-            $mimeTypes = $annotate->mimeTypes;
-            if (empty($mimeTypes)) {
-                $mimeTypes = $this->config->getResponseContentTypes();
-            }
+            $mimeTypes = $annotate->mimeTypes ?? $this->config->getResponseContentTypes();
 
             foreach ($mimeTypes as $mimeType) {
                 $content = (new Content())->setMimeType($mimeType);
 
-                $response = (new Response())->setCode($annotate->httpCode)->setDescription($annotate->description);
+                $response = (new Response())->setCode($annotate->statusCode)->setDescription($annotate->description);
 
-                if (empty($annotate->schemaFormat) && empty($annotate->schemaItems) && empty($annotate->refEntity)) {
+                // push basic response since no entity or format was defined
+                if (empty($annotate->schemaFormat) && empty($annotate->refEntity)) {
                     $response->pushContent($content);
                     $this->operation->pushResponse($response);
                     continue;
                 }
 
+                // push text/plain
                 if ($mimeType == 'text/plain') {
-                    $schema = (new Schema())->setType('string');
+                    $schema = (new Schema())->setType('string')->setFormat($annotate->schemaFormat ?? '');
+                    $content->setSchema($schema);
+                    $response->pushContent($content);
+                    $this->operation->pushResponse($response);
+                    continue;
+                }
 
-                    if ($annotate->schemaFormat) {
-                        $schema->setFormat($annotate->schemaFormat);
-                    }
-                } else {
-                    if (count($annotate->schemaItems) > 0) {
-                        $ref = reset($annotate->schemaItems);
-                        $action = 'index';
-                    }
-
+                try {
                     $schema = $this->getMimeTypeSchema(
                         $mimeType,
-                        $action ?? 'view',
+                        $annotate->schemaType,
                         $ref ?? $annotate->refEntity
                     );
+                    $content->setSchema(
+                        $annotate->schemaFormat ? $schema->setFormat($annotate->schemaFormat) : $schema
+                    );
+                    $response->pushContent($content);
+                    $this->operation->pushResponse($response);
+                } catch (\Exception $e) {
+                    throw new \RuntimeException(
+                        sprintf(
+                            'Unable to build response schema for `%s`, error: %s',
+                            $this->route->getTemplate(),
+                            $e->getMessage()
+                        )
+                    );
                 }
-
-                if (!empty($annotation->schemaType)) {
-                    $schema->setFormat($annotate->schemaType);
-                }
-
-                $content->setSchema($schema);
-
-                $response->pushContent($content);
-
-                $this->operation->pushResponse($response);
             }
         }
     }
 
     /**
-     * Sets error Responses using throw tags from Dock Block
+     * Set response from Crud actions
      *
      * @return void
      */
-    private function assignDocBlockExceptions(): void
+    private function assignFromCrudActions(): void
     {
-        if (!$this->doc->hasTag('throws')) {
+        if ($this->operation->hasSuccessResponseCode()) {
             return;
         }
 
-        $throws = array_filter($this->doc->getTagsByName('throws'), function ($tag) {
-            return $tag instanceof DocBlock\Tags\Throws;
-        });
-
-        foreach ($throws as $throw) {
-            $exception = new ExceptionHandler($throw, $this->swagger, $this->config);
-
-            $response = (new Response())
-                ->setCode($exception->getCode())
-                ->setDescription($exception->getMessage());
-
-            foreach ($this->config->getResponseContentTypes() as $mimeType) {
-                $response->pushContent(
-                    (new Content())
-                        ->setMimeType($mimeType)
-                        ->setSchema($exception->getSchema())
-                );
-            }
-
-            $this->operation->pushResponse($response);
-        }
-    }
-
-    /**
-     * Assigns Cake Models as Swagger Schema if possible.
-     *
-     * @return void
-     */
-    private function assignSchema(): void
-    {
         $action = strtolower($this->route->getAction());
-        $crudActions = ['index','add','view','edit'];
+        $crudActions = [
+            'index' => 'array',
+            'add' => 'object',
+            'view' => 'object',
+            'edit' => 'object',
+        ];
 
-        if (!$this->schema || $this->operation->hasSuccessResponseCode() || !in_array($action, $crudActions)) {
+        if (!$this->schema || !array_key_exists($action, $crudActions)) {
             return;
         }
 
         $response = (new Response())->setCode('200');
 
         foreach ($this->config->getResponseContentTypes() as $mimeType) {
-            $schema = $this->getMimeTypeSchema($mimeType, $action);
+            $schema = $this->getMimeTypeSchema($mimeType, $crudActions[$action]);
+
             $response->pushContent(
                 (new Content())
                     ->setSchema($schema)
@@ -228,11 +198,11 @@ class OperationResponse
      * Gets a schema based on mimetype
      *
      * @param string $mimeType a mime type (e.g. application/xml, application/json)
-     * @param string $action controller action (e.g. add, index, view, edit, delete)
+     * @param string $schemaType object or array
      * @param string|null $schema the openapi schema $ref or null
      * @return \SwaggerBake\Lib\OpenApi\Schema
      */
-    private function getMimeTypeSchema(string $mimeType, string $action, ?string $schema = null)
+    private function getMimeTypeSchema(string $mimeType, string $schemaType, ?string $schema = null)
     {
         if (is_null($schema)) {
             $schema = $this->schema instanceof Schema ? $this->schema : new Schema();
@@ -240,17 +210,17 @@ class OperationResponse
 
         switch ($mimeType) {
             case 'application/xml':
-                return (new XmlMedia($schema, $this->swagger))->buildSchema($action);
+                return (new XmlMedia($schema, $this->swagger))->buildSchema($schemaType);
             case 'application/hal+json':
             case 'application/vnd.hal+json':
-                return (new HalJson($schema, $this->swagger))->buildSchema($action);
+                return (new HalJson($schema, $this->swagger))->buildSchema($schemaType);
             case 'application/ld+json':
-                return (new JsonLd($schema, $this->swagger))->buildSchema($action);
+                return (new JsonLd($schema, $this->swagger))->buildSchema($schemaType);
             case 'text/plain':
                 return (new Schema())->setType('string');
         }
 
-        return (new Generic($schema, $this->swagger))->buildSchema($action);
+        return (new Generic($schema, $this->swagger))->buildSchema($schemaType);
     }
 
     /**

--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -40,11 +40,6 @@ class OperationResponse
     private $operation;
 
     /**
-     * @var \phpDocumentor\Reflection\DocBlock
-     */
-    private $doc;
-
-    /**
      * @var array
      */
     private $annotations;

--- a/src/Lib/Operation/OperationResponseException.php
+++ b/src/Lib/Operation/OperationResponseException.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace SwaggerBake\Lib\Operation;
+
+use phpDocumentor\Reflection\DocBlock;
+use SwaggerBake\Lib\Configuration;
+use SwaggerBake\Lib\OpenApi\Content;
+use SwaggerBake\Lib\OpenApi\Operation;
+use SwaggerBake\Lib\OpenApi\Response;
+use SwaggerBake\Lib\Swagger;
+
+class OperationResponseException
+{
+    /**
+     * @var \SwaggerBake\Lib\Swagger
+     */
+    private $swagger;
+
+    /**
+     * @var \SwaggerBake\Lib\Configuration
+     */
+    private $config;
+
+    /**
+     * @var \SwaggerBake\Lib\OpenApi\Operation
+     */
+    private $operation;
+
+    /**
+     * @var \phpDocumentor\Reflection\DocBlock
+     */
+    private $doc;
+
+    public function __construct(Swagger $swagger, Configuration $config, Operation $operation, DocBlock $doc)
+    {
+        $this->swagger = $swagger;
+        $this->config = $config;
+        $this->operation = $operation;
+        $this->doc = $doc;
+    }
+
+    /**
+     * Sets error Responses using throw tags from Dock Block
+     *
+     * @return \SwaggerBake\Lib\OpenApi\Operation
+     */
+    public function getOperation(): Operation
+    {
+        if (!$this->doc->hasTag('throws')) {
+            return $this->operation;
+        }
+
+        $throws = array_filter($this->doc->getTagsByName('throws'), function ($tag) {
+            return $tag instanceof DocBlock\Tags\Throws;
+        });
+
+        foreach ($throws as $throw) {
+            $exception = new ExceptionHandler($throw, $this->swagger, $this->config);
+
+            $response = (new Response())
+                ->setCode($exception->getCode())
+                ->setDescription($exception->getMessage());
+
+            foreach ($this->config->getResponseContentTypes() as $mimeType) {
+                $response->pushContent(
+                    (new Content())
+                        ->setMimeType($mimeType)
+                        ->setSchema($exception->getSchema())
+                );
+            }
+
+            $this->operation->pushResponse($response);
+        }
+
+        return $this->operation;
+    }
+}

--- a/src/Lib/Operation/OperationResponseException.php
+++ b/src/Lib/Operation/OperationResponseException.php
@@ -32,6 +32,12 @@ class OperationResponseException
      */
     private $doc;
 
+    /**
+     * @param \SwaggerBake\Lib\Swagger $swagger an instance of Swagger
+     * @param \SwaggerBake\Lib\Configuration $config an instance of Configuration
+     * @param \SwaggerBake\Lib\OpenApi\Operation $operation an instance of Operation
+     * @param \phpDocumentor\Reflection\DocBlock $doc an instance of DocBlock
+     */
     public function __construct(Swagger $swagger, Configuration $config, Operation $operation, DocBlock $doc)
     {
         $this->swagger = $swagger;

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -174,6 +174,7 @@ class Swagger
     {
         $name = $schema->getName();
         if (!isset($this->array['components']['schemas'][$name])) {
+            $schema->setRefPath('#/components/schemas/' . $name);
             $this->array['components']['schemas'][$name] = $schema;
         }
 
@@ -190,6 +191,7 @@ class Swagger
     {
         $name = $schema->getName();
         if (!isset($this->array['x-swagger-bake']['components']['schemas'][$name])) {
+            $schema->setRefPath('#/x-swagger-bake/components/schemas/' . $name);
             $this->array['x-swagger-bake']['components']['schemas'][$name] = $schema;
         }
 
@@ -206,6 +208,10 @@ class Swagger
     {
         if (isset($this->array['components']['schemas'][$name])) {
             return $this->array['components']['schemas'][$name];
+        }
+
+        if (isset($this->array['x-swagger-bake']['components']['schemas'][$name])) {
+            return $this->array['x-swagger-bake']['components']['schemas'][$name];
         }
 
         return null;
@@ -284,7 +290,7 @@ class Swagger
                     ->setName($schema->getAddSchemaName())
                     ->setProperties([])
                     ->setAllOf([
-                        ['$ref' => $schema->getWriteSchemaRef()],
+                        ['$ref' => $this->getSchemaByName($schema->getWriteSchemaName())->getRefPath()],
                     ])
                     ->setRequired(array_keys($propertiesRequiredOnCreate))
             );
@@ -299,7 +305,7 @@ class Swagger
                     ->setName($schema->getEditSchemaName())
                     ->setProperties([])
                     ->setAllOf([
-                        ['$ref' => $schema->getWriteSchemaRef()],
+                        ['$ref' => $this->getSchemaByName($schema->getWriteSchemaName())->getRefPath()],
                     ])
                     ->setRequired(array_keys($propertiesRequiredOnUpdate))
             );
@@ -394,7 +400,8 @@ class Swagger
         $factory = new SchemaFromYamlFactory();
 
         foreach ($this->array['components']['schemas'] as $schemaName => $schemaVar) {
-            $this->array['components']['schemas'][$schemaName] = $factory->create($schemaName, $schemaVar);
+            $schema = $factory->create($schemaName, $schemaVar)->setRefPath('#/components/schemas/' . $schemaName);
+            $this->array['components']['schemas'][$schemaName] = $schema;
         }
     }
 

--- a/tests/TestCase/Lib/Annotations/SwagResponseSchemaTest.php
+++ b/tests/TestCase/Lib/Annotations/SwagResponseSchemaTest.php
@@ -85,25 +85,10 @@ class SwagResponseSchemaTest extends TestCase
         $schema = $operation['responses']['200']['content']['application/json']['schema'];
         $this->assertEquals('#/components/schemas/Pet', $schema['$ref']);
 
-        $this->assertArrayHasKey('400', $operation['responses']);
-        $this->assertEquals('deprecated httpCode still works', $operation['responses']['400']['description']);
-
         $this->assertArrayHasKey('404', $operation['responses']);
         $this->assertEquals('new statusCode', $operation['responses']['404']['description']);
 
         $this->assertArrayHasKey('5XX', $operation['responses']);
         $this->assertEquals('status code range', $operation['responses']['5XX']['description']);
-    }
-
-    public function testSchemaItems()
-    {
-        $arr = json_decode($this->swagger->toString(), true);
-
-        $operation = $arr['paths']['/employees/schema-items']['get'];
-
-        $schema = $operation['responses']['200']['content']['application/json']['schema'];
-
-        $this->assertEquals('array', $schema['type']);
-        $this->assertEquals('#/components/schemas/Pet', $schema['items']['$ref']);
     }
 }

--- a/tests/TestCase/Lib/MediaType/GenericTest.php
+++ b/tests/TestCase/Lib/MediaType/GenericTest.php
@@ -51,7 +51,7 @@ class GenericTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
         $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config));
-        $schema = (new Generic('#/components/schemas/thing', $swagger))->buildSchema('index');
+        $schema = (new Generic('#/components/schemas/thing', $swagger))->buildSchema('array');
         $this->assertEquals(
             '#/x-swagger-bake/components/schemas/Generic-Collection',
             $schema->getAllOf()[0]['$ref']

--- a/tests/TestCase/Lib/MediaType/HalJsonTest.php
+++ b/tests/TestCase/Lib/MediaType/HalJsonTest.php
@@ -16,6 +16,11 @@ use SwaggerBake\Lib\Swagger;
 
 class HalJsonTest extends TestCase
 {
+    private const SCHEMA = '#/x-swagger-bake/components/schemas/';
+
+    /**
+     * @var string[]
+     */
     public $fixtures = [
         'plugin.SwaggerBake.Employees',
     ];
@@ -75,7 +80,7 @@ class HalJsonTest extends TestCase
             $schema->getProperties()['_embedded']->getItems()['allOf'][0]['$ref']
         );
         $this->assertEquals(
-            Schema::SCHEMA . 'Employee-Read',
+            self::SCHEMA . 'Employee-Read',
             $schema->getProperties()['_embedded']->getItems()['allOf'][1]['$ref']
         );
     }
@@ -95,7 +100,7 @@ class HalJsonTest extends TestCase
             $schema->getAllOf()[0]['$ref']
         );
         $this->assertEquals(
-            Schema::SCHEMA . 'Employee-Read',
+            self::SCHEMA . 'Employee-Read',
             $schema->getAllOf()[1]['$ref']
         );
     }

--- a/tests/TestCase/Lib/MediaType/JsonLdTest.php
+++ b/tests/TestCase/Lib/MediaType/JsonLdTest.php
@@ -15,6 +15,11 @@ use SwaggerBake\Lib\Swagger;
 
 class JsonLdTest extends TestCase
 {
+    private const SCHEMA = '#/x-swagger-bake/components/schemas/';
+
+    /**
+     * @var string[]
+     */
     public $fixtures = [
         'plugin.SwaggerBake.Employees',
     ];
@@ -74,7 +79,7 @@ class JsonLdTest extends TestCase
             $schema->getProperties()['member']->getItems()['allOf'][0]['$ref']
         );
         $this->assertEquals(
-            Schema::SCHEMA . 'Employee-Read',
+            self::SCHEMA . 'Employee-Read',
             $schema->getProperties()['member']->getItems()['allOf'][1]['$ref']
         );
     }
@@ -94,7 +99,7 @@ class JsonLdTest extends TestCase
             $schema->getAllOf()[0]['$ref']
         );
         $this->assertEquals(
-            Schema::SCHEMA . 'Employee-Read',
+            self::SCHEMA . 'Employee-Read',
             $schema->getAllOf()[1]['$ref']
         );
     }

--- a/tests/TestCase/Lib/MediaType/XmlTest.php
+++ b/tests/TestCase/Lib/MediaType/XmlTest.php
@@ -51,7 +51,7 @@ class XmlTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
         $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config));
-        $schema = (new Xml('#/components/schemas/thing', $swagger))->buildSchema('index');
+        $schema = (new Xml('#/components/schemas/thing', $swagger))->buildSchema('array');
         $this->assertEquals(
             '#/x-swagger-bake/components/schemas/Generic-Collection',
             $schema->getAllOf()[0]['$ref']

--- a/tests/TestCase/Lib/Operation/OperationResponseTest.php
+++ b/tests/TestCase/Lib/Operation/OperationResponseTest.php
@@ -90,7 +90,7 @@ class OperationResponseTest extends TestCase
         }
     }
 
-    public function testGetOperationWithAnnotatedResponse()
+    public function testGetOperationWithAnnotatedResponse(): void
     {
         $route = $this->routes['employees:index'];
 
@@ -98,7 +98,6 @@ class OperationResponseTest extends TestCase
             (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
-            DocBlockFactory::createInstance()->create('/** @throws Exception */'),
             [
                 new SwagResponseSchema([
                     'httpCode' => 200,
@@ -110,11 +109,10 @@ class OperationResponseTest extends TestCase
 
         $operation = $operationResponse->getOperationWithResponses();
 
-        $this->assertInstanceOf(Response::class, $operation->getResponseByCode(200));
-        $this->assertInstanceOf(Response::class, $operation->getResponseByCode(500));
+        $this->assertInstanceOf(Response::class, $operation->getResponseByCode('200'));
     }
 
-    public function testGetOperationWithSchemaResponse()
+    public function testGetOperationWithSchemaResponse(): void
     {
         $route = $this->routes['employees:add'];
 
@@ -127,7 +125,6 @@ class OperationResponseTest extends TestCase
             (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
-            DocBlockFactory::createInstance()->create('/**  */'),
             [],
             $route,
             $schema
@@ -135,10 +132,10 @@ class OperationResponseTest extends TestCase
 
         $operation = $operationResponse->getOperationWithResponses();
 
-        $this->assertInstanceOf(Response::class, $operation->getResponseByCode(200));
+        $this->assertInstanceOf(Response::class, $operation->getResponseByCode('200'));
     }
 
-    public function testAddOperationWithNoResponseDefined()
+    public function testAddOperationWithNoResponseDefined(): void
     {
         $route = $this->routes['employees:add'];
 
@@ -146,14 +143,13 @@ class OperationResponseTest extends TestCase
             (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
-            DocBlockFactory::createInstance()->create('/**  */'),
             [],
             $route,
             null
         );
 
         $operation = $operationResponse->getOperationWithResponses();
-        $response = $operation->getResponseByCode(200);
+        $response = $operation->getResponseByCode('200');
         $this->assertNotEmpty($response);
 
         $content = $response->getContentByMimeType('application/json');
@@ -162,7 +158,7 @@ class OperationResponseTest extends TestCase
         $this->assertNotEmpty($content->getSchema());
     }
 
-    public function testDeleteActionResponseWithHttp204()
+    public function testDeleteActionResponseWithHttp204(): void
     {
         $route = $this->routes['employees:delete'];
 
@@ -170,17 +166,16 @@ class OperationResponseTest extends TestCase
             (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
-            DocBlockFactory::createInstance()->create('/**  */'),
             [],
             $route,
             null
         );
 
         $operation = $operationResponse->getOperationWithResponses();
-        $this->assertNotEmpty($operation->getResponseByCode(204));
+        $this->assertNotEmpty($operation->getResponseByCode('204'));
     }
 
-    public function testNoResponseDefined()
+    public function testNoResponseDefined(): void
     {
         $route = $this->routes['employees:noresponsedefined'];
 
@@ -188,14 +183,13 @@ class OperationResponseTest extends TestCase
             (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
-            DocBlockFactory::createInstance()->create('/**  */'),
             [],
             $route,
             null
         );
 
         $operation = $operationResponse->getOperationWithResponses();
-        $response = $operation->getResponseByCode(200);
+        $response = $operation->getResponseByCode('200');
         $this->assertNotEmpty($response);
 
         $content = $response->getContentByMimeType('application/json');
@@ -203,7 +197,7 @@ class OperationResponseTest extends TestCase
         $this->assertNotEmpty($content->getSchema());
     }
 
-    public function testGetOperationWithSwagResponseSchemaRefEntity()
+    public function testGetOperationWithSwagResponseSchemaRefEntity(): void
     {
         $route = $this->routes['employees:index'];
 
@@ -211,9 +205,9 @@ class OperationResponseTest extends TestCase
             (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
-            DocBlockFactory::createInstance()->create('/** */'),
             [
                 new SwagResponseSchema([
+                    'schemaType' => 'array',
                     'refEntity' => '#/components/schema/Employee',
                 ]),
             ],
@@ -221,42 +215,15 @@ class OperationResponseTest extends TestCase
             null
         );
 
-        $operation = $operationResponse->getOperationWithResponses();
+        $content = $operationResponse
+            ->getOperationWithResponses()
+            ->getResponseByCode('200')
+            ->getContentByMimeType('application/json');
 
-        $content = $operation->getResponseByCode(200)->getContentByMimeType('application/json');
-
-        $this->assertEquals('#/components/schema/Employee', $content->getSchema()->getRefEntity());
-    }
-
-    public function testGetOperationWithSwagResponseSchemaItems()
-    {
-        $route = $this->routes['employees:index'];
-
-        $operationResponse = new OperationResponse(
-            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
-            $this->config,
-            new Operation(),
-            DocBlockFactory::createInstance()->create('/** */'),
-            [
-                new SwagResponseSchema([
-                    'schemaItems' => [ '$ref' => '#/components/schema/Employee']
-                ]),
-            ],
-            $route,
-            null
-        );
-
-        $operation = $operationResponse->getOperationWithResponses();
-
-        $content = $operation->getResponseByCode(200)->getContentByMimeType('application/json');
-
-
-        $this->assertEquals('array', $content->getSchema()->getType());
-        $this->assertArrayHasKey('$ref', $content->getSchema()->getItems());
         $this->assertEquals('#/components/schema/Employee', $content->getSchema()->getItems()['$ref']);
     }
 
-    public function testGetOperationWithSwagResponseSchemaTextPlain()
+    public function testGetOperationWithSwagResponseSchemaTextPlain(): void
     {
         $route = $this->routes['employees:textplain'];
 
@@ -264,7 +231,6 @@ class OperationResponseTest extends TestCase
             (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
             $this->config,
             new Operation(),
-            DocBlockFactory::createInstance()->create('/** */'),
             [
                 new SwagResponseSchema([
                     'mimeTypes' => ['text/plain'],
@@ -277,7 +243,7 @@ class OperationResponseTest extends TestCase
 
         $operation = $operationResponse->getOperationWithResponses();
 
-        $content = $operation->getResponseByCode(200)->getContentByMimeType('text/plain');
+        $content = $operation->getResponseByCode('200')->getContentByMimeType('text/plain');
 
         $this->assertEquals('string', $content->getSchema()->getType());
         $this->assertEquals('date-time', $content->getSchema()->getFormat());

--- a/tests/TestCase/Lib/Operation/OperationResponseYamlTest.php
+++ b/tests/TestCase/Lib/Operation/OperationResponseYamlTest.php
@@ -80,7 +80,6 @@ class OperationResponseYamlTest extends TestCase
             $swagger,
             $this->config,
             new Operation(),
-            DocBlockFactory::createInstance()->create('/** @throws Exception */'),
             [],
             $route,
             $swagger->getArray()['components']['schemas']['Employee']

--- a/tests/test_app/src/Controller/EmployeesController.php
+++ b/tests/test_app/src/Controller/EmployeesController.php
@@ -149,22 +149,11 @@ class EmployeesController extends AppController
     }
 
     /**
-     * @Swag\SwagResponseSchema(refEntity="#/components/schemas/Pet")
-     * @Swag\SwagResponseSchema(refEntity="", description="deprecated httpCode still works", httpCode=400)
-     * @Swag\SwagResponseSchema(refEntity="", description="new statusCode", statusCode="404")
-     * @Swag\SwagResponseSchema(refEntity="", description="status code range", statusCode="5XX")
+     * @Swag\SwagResponseSchema(schemaType="object", refEntity="#/components/schemas/Pet")
+     * @Swag\SwagResponseSchema(description="new statusCode", statusCode="404")
+     * @Swag\SwagResponseSchema(description="status code range", statusCode="5XX")
      */
     public function customResponseSchema()
-    {
-        $hello = 'world';
-        $this->set(compact('hello'));
-        $this->viewBuilder()->setOption('serialize', ['hello']);
-    }
-
-    /**
-     * @Swag\SwagResponseSchema(schemaItems={"$ref"="#/components/schemas/Pet"})
-     */
-    public function schemaItems()
     {
         $hello = 'world';
         $this->set(compact('hello'));


### PR DESCRIPTION
- Removes deprecated properties from SwagResponseSchema
- Remove SwagResponseSchema.schemaItems
- Updates documentation in annotations.md
- Refactors all MediaType classes to use schemaType instead of crud
action
- Breaks parsing `@throw` tag for exception responses into its own class,
was previously part of OperationResponse, now OperationResponseException.
- Removes getters for write, add, edit, read schemaRefs from Schema
class. Use new refPath property instead. This is set when schema is
added now.
- Removes const SCHEMA from Schema class
- Updates unit tests.