### PR TITLE
Cleanup

### DIFF
--- a/src/Lib/OpenApi/Operation.php
+++ b/src/Lib/OpenApi/Operation.php
@@ -59,8 +59,7 @@ class Operation implements JsonSerializable
         $vars = get_object_vars($this);
         $vars = ArrayUtility::convertNullToEmptyString($vars, ['summary','description']);
         $vars['deprecated'] = $vars['isDeprecated'];
-        unset($vars['isDeprecated']);
-        unset($vars['httpMethod']);
+        $vars = ArrayUtility::removeKeysMatching($vars, ['isDeprecated', 'httpMethod', 'sortOrder']);
 
         // remove request body got GET and DELETE
         if (in_array($this->httpMethod, ['GET', 'DELETE']) || empty($vars['requestBody'])) {

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -78,7 +78,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             $vars,
             [
                 'format','title','description','multipleOf','minimum','maximum','minLength','maxLength','pattern',
-                'minItems','maxItems','minProperties','maxProperties','items','enum'
+                'minItems','maxItems','minProperties','maxProperties','items','enum',
             ]
         );
 

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -78,7 +78,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             $vars,
             [
                 'format','title','description','multipleOf','minimum','maximum','minLength','maxLength','pattern',
-                'minItems','maxItems','minProperties','maxProperties',
+                'minItems','maxItems','minProperties','maxProperties','items'
             ]
         );
 

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -78,7 +78,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             $vars,
             [
                 'format','title','description','multipleOf','minimum','maximum','minLength','maxLength','pattern',
-                'minItems','maxItems','minProperties','maxProperties','items'
+                'minItems','maxItems','minProperties','maxProperties','items','enum'
             ]
         );
 

--- a/src/Lib/Operation/OperationPathParameter.php
+++ b/src/Lib/Operation/OperationPathParameter.php
@@ -54,28 +54,24 @@ class OperationPathParameter
     {
         $pieces = explode('/', $this->route->getTemplate());
         $results = array_filter($pieces, function ($piece) {
-            return str_starts_with($piece, ':');
+            return str_starts_with($piece, ':') || str_starts_with($piece, '{');
         });
 
         $properties = $this->schema instanceof Schema ? $this->schema->getProperties() : [];
 
         foreach ($results as $result) {
-            $name = strtolower($result);
+            $id = str_replace([':','{','}'], ['','',''], strtolower($result));
 
-            if (substr($name, 0, 1) == ':') {
-                $name = substr($name, 1);
-            }
-
-            if (isset($properties[$name])) {
-                $type = $properties[$name]->getType();
-                $format = $properties[$name]->getFormat();
-                $description = $properties[$name]->getDescription();
+            if (isset($properties[$id])) {
+                $type = $properties[$id]->getType();
+                $format = $properties[$id]->getFormat();
+                $description = $properties[$id]->getDescription();
             }
 
             $this->operation->pushParameter(
                 new Parameter(
                     in: 'path',
-                    name: $name,
+                    name: $id,
                     description: $description ?? null,
                     required: true,
                     schema: (new Schema())->setType($type ?? 'string')->setFormat($format ?? '')

--- a/tests/TestCase/Lib/SwaggerOperationTest.php
+++ b/tests/TestCase/Lib/SwaggerOperationTest.php
@@ -45,10 +45,10 @@ class SwaggerOperationTest extends TestCase
                     ],
                 ]
             ]);
-            $builder->resources('Departments', function (RouteBuilder $routes) {
+/*            $builder->resources('Departments', function (RouteBuilder $routes) {
                 $routes->resources('DepartmentEmployees');
             });
-            $builder->resources('EmployeeSalaries');
+            $builder->resources('EmployeeSalaries');*/
         });
         $this->router = $router;
 
@@ -199,5 +199,16 @@ class SwaggerOperationTest extends TestCase
         $this->assertArrayHasKey('BearerAuth', $securities[0]);
         $this->assertArrayHasKey('ApiKey', $securities[1]);
         $this->assertCount(2, $securities[0]['BearerAuth']);
+    }
+
+    public function test_path_parameter_is_defined(): void
+    {
+        $arr = json_decode($this->swagger->toString(), true);
+        $operation = $arr['paths']['/employees/{id}']['get'];
+
+        $this->assertEquals('path', $operation['parameters'][0]['in']);
+        $this->assertEquals('id', $operation['parameters'][0]['name']);
+        $this->assertEquals('integer', $operation['parameters'][0]['schema']['type']);
+        $this->assertEquals('int64', $operation['parameters'][0]['schema']['format']);
     }
 }

--- a/tests/TestCase/Lib/SwaggerOperationTest.php
+++ b/tests/TestCase/Lib/SwaggerOperationTest.php
@@ -45,10 +45,10 @@ class SwaggerOperationTest extends TestCase
                     ],
                 ]
             ]);
-/*            $builder->resources('Departments', function (RouteBuilder $routes) {
+            $builder->resources('Departments', function (RouteBuilder $routes) {
                 $routes->resources('DepartmentEmployees');
             });
-            $builder->resources('EmployeeSalaries');*/
+            $builder->resources('EmployeeSalaries');
         });
         $this->router = $router;
 


### PR DESCRIPTION
- Remove `sortOrder` from Operation json output
- Remove `items` from SchemaProperty json output
- Path parameter was not being added to Operation parameters 