### PR TITLE
CakePHP compatibility check

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -48,3 +48,29 @@ jobs:
           echo ${{ matrix.php-versions }}
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
           vendor/bin/php-coveralls --coverage_clover=clover.xml -v
+
+  compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['~4.0.0' ,'~4.1.0' ,'~4.2.0', '^4.3']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl
+
+      - name: PHP Version
+        run: php -v
+
+      - name: CakePHP ${{matrix.version}} Compatability
+        run: |
+          composer self-update
+          rm -rf composer.lock
+          composer require cakephp/cakephp:${{matrix.version}} --no-update
+          composer install --prefer-dist --no-progress
+          composer test

--- a/src/Command/CommandTrait.php
+++ b/src/Command/CommandTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace SwaggerBake\Command;
 
 use Cake\Core\Configure;
-use Cake\Core\Exception\CakeException;
+use Exception;
 use SwaggerBake\Lib\AnnotationLoader;
 use SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException;
 use SwaggerBake\Lib\ExtensionLoader;
@@ -25,9 +25,11 @@ trait CommandTrait
             Configure::delete('SwaggerBake');
         }
 
+        // Catch a generic exception here to support older versions of CakePHP which throw
+        // \Cake\Core\Exception\Exception instead of \Cake\Core\Exception\CakeException in newer versions
         try {
             Configure::load($config, 'default');
-        } catch (CakeException $e) {
+        } catch (Exception $e) {
             throw new SwaggerBakeRunTimeException(
                 "SwaggerBake config file `$config` is missing or " . get_class($e) . ' ' . $e->getMessage()
             );

--- a/src/Lib/Operation/ExceptionHandler.php
+++ b/src/Lib/Operation/ExceptionHandler.php
@@ -66,7 +66,7 @@ class ExceptionHandler
                     '403' => '\Cake\Http\Exception\ForbiddenException',
                     '404' => '\Cake\Datasource\Exception\RecordNotFoundException',
                     '405' => '\Cake\Http\Exception\MethodNotAllowedException',
-                    '500' => '\Exception'
+                    '500' => '\Exception',
                 ];
 
                 $code = array_search($exceptionClass, $exceptions);

--- a/src/Lib/Operation/ExceptionHandler.php
+++ b/src/Lib/Operation/ExceptionHandler.php
@@ -58,7 +58,23 @@ class ExceptionHandler
             $instance = new $exceptionClass();
             if ($instance instanceof CakeException && $instance->getCode() > 0) {
                 $httpCode = (int)$instance->getCode();
+            } else {
+                // Handle older version of CakePHP 4.x that predate CakeException
+                $exceptions = [
+                    '400' => '\Cake\Http\Exception\BadRequestException',
+                    '401' => '\Cake\Http\Exception\UnauthorizedException',
+                    '403' => '\Cake\Http\Exception\ForbiddenException',
+                    '404' => '\Cake\Datasource\Exception\RecordNotFoundException',
+                    '405' => '\Cake\Http\Exception\MethodNotAllowedException',
+                    '500' => '\Exception'
+                ];
+
+                $code = array_search($exceptionClass, $exceptions);
+                if ($code) {
+                    $httpCode = $code;
+                }
             }
+
             if (empty($message)) {
                 $class = get_class($instance);
                 $pieces = explode('\\', $class);

--- a/src/Lib/Schema/SchemaFactory.php
+++ b/src/Lib/Schema/SchemaFactory.php
@@ -31,17 +31,17 @@ class SchemaFactory
     private $validator;
 
     /**
-     * @var string
+     * @var int
      */
     public const WRITEABLE_PROPERTIES = 2;
 
     /**
-     * @var string
+     * @var int
      */
     public const READABLE_PROPERTIES = 4;
 
     /**
-     * @var string
+     * @var int
      */
     public const ALL_PROPERTIES = 6;
 


### PR DESCRIPTION
Resolves #339 

- Adds checks for CakePHP 4.0 - 4.3 when running as PHP 7.4
- Fixes some minor compatibility issues in CakePHP 4.0 and 4.1