### PR TITLE
Bump phpstan from 6 to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Check out the demo applications for examples.
 
 This is built for CakePHP 4.x only. Supported versions:
 
-| Version | Branch | Cake Version  | PHP Version | 
-|---------|--------|---------------|-------------|
-| 2.*     | master | 4.2 or higher | 8.0+        |
+| Version | Branch                                                                    | Cake Version  | PHP Version | 
+|---------|---------------------------------------------------------------------------|---------------|-------------|
+| 2.*     | master                                                                    | 4.2 or higher | 8.0+        |
 | 1.*     | [1.next](https://github.com/cnizzardini/cakephp-swagger-bake/tree/1.next) | 4.0 - 4.3     | 7.2+        | 
 
 ## Table of Contents

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -541,17 +541,17 @@ Class level attribute for modifying OpenAPI Schema.
 
 You can use the constants below when defining `visibility`:
 
-| Name                              | Value | Description                                                                                                                                                                                                                                                              |
-|-----------------------------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `OpenApiSchema::VISIBILE_DEFAULT` | 1     | Default behavior. Adds the schema to `#/components/schema/{SchemaName}` if it matches a controller with a RESTful route.                                                                                                                                                 |
-| `OpenApiSchema::VISIBILE_ALWAYS`  | 2     | Always add the schema to `#/components/schema/{SchemaName}`.                                                                                                                                                                                                             |
-| `OpenApiSchema::VISIBILE_HIDDEN`  | 3     | Never add the schema to `#/components/schema/{SchemaName}` and instead adds it to `#/x-swagger-bake/components/schema/{SchemaName}`. This hides the schema from the Swagger UIs Schemas section, but still allows the schema to be used for request and response bodies. |
-| `OpenApiSchema::VISIBILE_NEVER`   | 4     | Never add the schema anywhere. Warning this can break request body definitions and response samples.                                                                                                                                                                     |
+| Name                             | Value | Description                                                                                                                                                                                                                                                              |
+|----------------------------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `OpenApiSchema::VISIBLE_DEFAULT` | 1     | Default behavior. Adds the schema to `#/components/schema/{SchemaName}` if it matches a controller with a RESTful route.                                                                                                                                                 |
+| `OpenApiSchema::VISIBLE_ALWAYS`  | 2     | Always add the schema to `#/components/schema/{SchemaName}`.                                                                                                                                                                                                             |
+| `OpenApiSchema::VISIBLE_HIDDEN`  | 3     | Never add the schema to `#/components/schema/{SchemaName}` and instead adds it to `#/x-swagger-bake/components/schema/{SchemaName}`. This hides the schema from the Swagger UIs Schemas section, but still allows the schema to be used for request and response bodies. |
+| `OpenApiSchema::VISIBLE_NEVER`   | 4     | Never add the schema anywhere. Warning this can break request body definitions and response samples.                                                                                                                                                                     |
 
 Example:
 
 ```php
-#[OpenApiSchema(visbility: OpenApiSchema::VISIBILE_ALWAYS, title: 'Always visible schema')]
+#[OpenApiSchema(visbility: OpenApiSchema::VISIBLE_ALWAYS, title: 'Always visible schema')]
 class Actor extends Entity{}
 ```
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 6
+    level: 7
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
     treatPhpDocTypesAsCertain: false

--- a/src/Command/BakeCommand.php
+++ b/src/Command/BakeCommand.php
@@ -48,13 +48,18 @@ class BakeCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
-        $this->loadConfig($args->getOption('config'));
+        $this->loadConfig($args);
 
         $io->out('Running...');
 
         $config = new Configuration();
         ValidateConfiguration::validate($config);
+        /** @var string $output */
         $output = $args->getOption('output') ?? $config->getJson();
+        if (empty($output) || !is_string($output)) {
+            $io->out('<error>Output must be a string in file path format</error>');
+            $this->abort();
+        }
 
         $swagger = (new SwaggerFactory())->create();
         foreach ($swagger->getOperationsWithNoHttp20x() as $operation) {

--- a/src/Command/CommandTrait.php
+++ b/src/Command/CommandTrait.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Command;
 
+use Cake\Console\Arguments;
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
 use SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException;
@@ -13,13 +14,17 @@ trait CommandTrait
     /**
      * Loads configuration
      *
-     * @param string $config your applications swagger_bake config
+     * @param \Cake\Console\Arguments $args Cli Arguments instance
      * @return void
      * @throws \SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException if config file not found
      * @throws \RuntimeException if config var SwaggerBake not found
      */
-    public function loadConfig(string $config = 'swagger_bake'): void
+    public function loadConfig(Arguments $args): void
     {
+        $config = $args->getOption('config');
+        if (!is_string($config) || empty($config)) {
+            $config = 'swagger_bake';
+        }
         if ($config !== 'swagger_bake') {
             Configure::delete('SwaggerBake');
         }

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -49,8 +49,9 @@ class InstallCommand extends Command
         $io->out('| SwaggerBake Install');
         $io->hr();
 
+        /** @var string $assets */
         $assets = $args->getOption('assets_test') ?? __DIR__ . DS . '..' . DS . '..' . DS . 'assets';
-        if (!is_dir($assets)) {
+        if (empty($assets) || !is_string($assets) || !is_dir($assets)) {
             $io->error('Unable to locate assets directory, please install manually');
             $this->abort();
         }
@@ -94,11 +95,22 @@ class InstallCommand extends Command
             $this->abort();
         }
 
+        /** @var string $contents */
         $contents = file_get_contents($swaggerYml);
+        if (!$contents) {
+            $io->error("Unable to get contents of $swaggerYml");
+            $this->abort();
+        }
+
         $contents = str_replace('YOUR-SERVER-HERE', $path, $contents);
         file_put_contents($swaggerYml, $contents);
 
+        /** @var string $contents */
         $contents = file_get_contents($configDir . 'swagger_bake.php');
+        if (!$contents) {
+            $io->error('Unable to get contents of swagger_bake.php');
+            $this->abort();
+        }
         $contents = str_replace('/your-relative-api-url', $path, $contents);
         file_put_contents($configDir . 'swagger_bake.php', $contents);
 

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -12,6 +12,8 @@ use Cake\Console\ConsoleOptionParser;
  * Class InstallCommand
  *
  * @package SwaggerBake\Command
+ * @SuppressWarnings(PHPMD.NPathComplexity)
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
  */
 class InstallCommand extends Command
 {

--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -53,7 +53,7 @@ class ModelCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
-        $this->loadConfig($args->getOption('config'));
+        $this->loadConfig($args);
 
         $io->hr();
         $io->out('| SwaggerBake is checking your models...');

--- a/src/Command/RouteCommand.php
+++ b/src/Command/RouteCommand.php
@@ -49,7 +49,7 @@ class RouteCommand extends Command
      */
     public function execute(Arguments $args, ConsoleIo $io)
     {
-        $this->loadConfig($args->getOption('config'));
+        $this->loadConfig($args);
 
         $io->hr();
         $io->out('| SwaggerBake is checking your routes...');

--- a/src/Controller/Component/SwaggerUiComponent.php
+++ b/src/Controller/Component/SwaggerUiComponent.php
@@ -83,11 +83,12 @@ class SwaggerUiComponent extends Component
      */
     public function getDocType(ServerRequest $request): string
     {
-        $docType = 'swagger';
-        if (!empty($request->getQuery('doctype'))) {
-            $docType = h(strtolower($request->getQuery('doctype')));
+        if (empty($request->getQuery('doctype')) || !is_string($request->getQuery('doctype'))) {
+            return 'swagger';
         }
 
-        return in_array(strtolower($docType), ['swagger','redoc']) ? $docType : 'swagger';
+        $docType = h(strtolower($request->getQuery('doctype')));
+
+        return in_array($docType, ['swagger','redoc']) ? $docType : 'swagger';
     }
 }

--- a/src/Lib/Attribute/OpenApiResponse.php
+++ b/src/Lib/Attribute/OpenApiResponse.php
@@ -15,7 +15,7 @@ class OpenApiResponse
      * @param string $statusCode The HTTP status code this response represents.
      * @param string|null $ref An optional existing $ref from your OpenAPI YAML. If not set, the entity
      *      associated with your controller per cakephp convention will be assumed.
-     * @param string|null $schema An optional FQN (e.g. '\App\MyResponse') to a class with an OpenApiSchema attribute
+     * @param class-string|null $schema An optional FQN (e.g. '\App\MyResponse') to a class with an OpenApiSchema attribute
      *      that describes the response.
      * @param string|null $description An optional response description.
      * @param array|null $mimeTypes An optional array of mime types, if none are given then the defaults from your

--- a/src/Lib/Attribute/OpenApiSchema.php
+++ b/src/Lib/Attribute/OpenApiSchema.php
@@ -13,21 +13,41 @@ class OpenApiSchema
     /**
      *  Default behavior. Adds the schema if it matches a controller with a restful route.
      */
-    public const VISIBILE_DEFAULT = 1;
+    public const VISIBLE_DEFAULT = 1;
 
     /**
      * Always add the schema.
      */
-    public const VISIBILE_ALWAYS = 2;
+    public const VISIBLE_ALWAYS = 2;
 
     /**
      * Never add the schema to the default location, but adds it to vendor location. This hides the schema from the
      * Swagger UIs Schemas section, but still allows the schema to be used for request and response bodies.
      */
-    public const VISIBILE_HIDDEN = 3;
+    public const VISIBLE_HIDDEN = 3;
 
     /**
      * Never add the Schema. Warning this can break request body definitions and response samples.
+     */
+    public const VISIBLE_NEVER = 4;
+
+    /**
+     * @deprecated deprecated because of misspelling
+     */
+    public const VISIBILE_DEFAULT = 1;
+
+    /**
+     * @deprecated deprecated because of misspelling
+     */
+    public const VISIBILE_ALWAYS = 2;
+
+    /**
+     * @deprecated deprecated because of misspelling
+     */
+    public const VISIBILE_HIDDEN = 3;
+
+    /**
+     * @deprecated deprecated because of misspelling
      */
     public const VISIBILE_NEVER = 4;
 

--- a/src/Lib/MediaType/HalJson.php
+++ b/src/Lib/MediaType/HalJson.php
@@ -116,6 +116,7 @@ final class HalJson implements MediaTypeInterface
             }
 
             if ($property->getType() === 'object') {
+                // @phpstan-ignore-next-line
                 $properties['_embedded']['type'] = 'object';
                 $properties['_embedded']['properties'][$key] = $items;
             } else {
@@ -123,6 +124,7 @@ final class HalJson implements MediaTypeInterface
                     $items['allOf'][] = ['$ref' => $items['$ref']];
                     unset($items['$ref']);
                 }
+                // @phpstan-ignore-next-line
                 $properties['_embedded']['items'] = $items;
             }
         }

--- a/src/Lib/MediaType/JsonLd.php
+++ b/src/Lib/MediaType/JsonLd.php
@@ -103,17 +103,22 @@ final class JsonLd implements MediaTypeInterface
     private function recursion(array $properties): array
     {
         foreach ($properties as $key => $property) {
+            // @phpstan-ignore-next-line
             if (!in_array($property->getType(), ['object','array'])) {
                 continue;
             }
 
             unset($properties[$key]);
+            // @phpstan-ignore-next-line
             $items = $property->getItems();
             $items['allOf'][] = ['$ref' => self::JSONLD_ITEM];
+            // @phpstan-ignore-next-line
             if ($property->getRefEntity()) {
+                // @phpstan-ignore-next-line
                 $items['allOf'][] = ['$ref' => $property->getRefEntity()];
             }
 
+            // @phpstan-ignore-next-line
             if ($property->getType() === 'object') {
                 $properties[$key] = $items;
             } else {
@@ -121,6 +126,7 @@ final class JsonLd implements MediaTypeInterface
                     $items['allOf'][] = ['$ref' => $items['$ref']];
                     unset($items['$ref']);
                 }
+                // @phpstan-ignore-next-line
                 $properties[$key]['items'] = $items;
             }
         }

--- a/src/Lib/Model/ModelScanner.php
+++ b/src/Lib/Model/ModelScanner.php
@@ -143,7 +143,7 @@ class ModelScanner
             return $routeDecorator !== null;
         }
 
-        return $schema->visibility != OpenApiSchema::VISIBILE_NEVER;
+        return $schema->visibility != OpenApiSchema::VISIBLE_NEVER;
     }
 
     /**

--- a/src/Lib/OpenApi/Content.php
+++ b/src/Lib/OpenApi/Content.php
@@ -33,23 +33,20 @@ class Content implements JsonSerializable
         unset($vars['mimeType']);
         unset($vars['schema']);
 
-        switch (gettype($this->schema)) {
-            case 'string':
-                $vars['schema']['$ref'] = $this->schema;
-                break;
-            case 'object':
-                if ($this->schema->getRefPath()) {
-                    $vars['schema']['required'] = array_values($this->schema->getRequired());
-                    $vars['schema']['allOf'][] = [
-                        '$ref' => $this->schema->getRefPath(),
-                    ];
-                    if (empty($vars['schema']['required'])) {
-                        unset($vars['schema']['required']);
-                    }
-                    break;
+        if ($this->schema instanceof Schema) {
+            if ($this->schema->getRefPath()) {
+                $vars['schema']['required'] = array_values($this->schema->getRequired());
+                $vars['schema']['allOf'][] = [
+                    '$ref' => $this->schema->getRefPath(),
+                ];
+                if (empty($vars['schema']['required'])) {
+                    unset($vars['schema']['required']);
                 }
+            } else {
                 $vars['schema'] = $this->schema;
-                break;
+            }
+        } elseif (is_string($this->schema)) {
+            $vars['schema']['$ref'] = $this->schema;
         }
 
         return $vars;

--- a/src/Lib/OpenApi/PathSecurity.php
+++ b/src/Lib/OpenApi/PathSecurity.php
@@ -14,17 +14,18 @@ use JsonSerializable;
 class PathSecurity implements JsonSerializable
 {
     /**
-     * @var string
+     * @todo needs documentation
+     * @param string $name needs documentation
+     * @param array $scopes needs documentation
      */
-    private $name = '';
+    public function __construct(
+        private string $name = '',
+        private array $scopes = []
+    ) {
+    }
 
     /**
-     * @var string[]
-     */
-    private $scopes = [];
-
-    /**
-     * @return array|array[]
+     * @return array
      */
     public function toArray(): array
     {

--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -55,7 +55,7 @@ class Schema implements JsonSerializable, SchemaInterface
         private array $allOf = [],
         private array $not = [],
         private ?Xml $xml = null,
-        private int $visibility = OpenApiSchema::VISIBILE_DEFAULT,
+        private int $visibility = OpenApiSchema::VISIBLE_DEFAULT,
         private ?string $refPath = null,
         private bool $isCustomSchema = false,
     ) {

--- a/src/Lib/OpenApiSchemaGenerator.php
+++ b/src/Lib/OpenApiSchemaGenerator.php
@@ -42,9 +42,9 @@ class OpenApiSchemaGenerator
                 continue;
             }
 
-            if (in_array($schema->getVisibility(), [OpenApiSchema::VISIBILE_DEFAULT, OpenApiSchema::VISIBILE_ALWAYS])) {
+            if (in_array($schema->getVisibility(), [OpenApiSchema::VISIBLE_DEFAULT, OpenApiSchema::VISIBLE_ALWAYS])) {
                 $openapi = $this->addSchema($openapi, $schema);
-            } elseif ($schema->getVisibility() == OpenApiSchema::VISIBILE_HIDDEN) {
+            } elseif ($schema->getVisibility() == OpenApiSchema::VISIBLE_HIDDEN) {
                 $openapi = $this->addVendorSchema($openapi, $schema);
             }
         }

--- a/src/Lib/Operation/DtoParser.php
+++ b/src/Lib/Operation/DtoParser.php
@@ -21,11 +21,14 @@ class DtoParser
     /**
      * @param \ReflectionClass|string $reflection ReflectionClass instance or the fully qualified namespace of the DTO
      * to be converted into a ReflectionClass instance.
-     * @throws \ReflectionException
      */
     public function __construct(ReflectionClass|string $reflection)
     {
-        $this->reflection = is_string($reflection) ? new ReflectionClass($reflection) : $reflection;
+        if (is_string($reflection) && class_exists($reflection)) {
+            $this->reflection = new ReflectionClass($reflection);
+        } elseif ($reflection instanceof ReflectionClass) {
+            $this->reflection = $reflection;
+        }
     }
 
     /**

--- a/src/Lib/Operation/DtoParser.php
+++ b/src/Lib/Operation/DtoParser.php
@@ -16,14 +16,16 @@ use SwaggerBake\Lib\Attribute\OpenApiSchemaProperty;
  */
 class DtoParser
 {
+    private ReflectionClass $reflection;
+
     /**
      * @param \ReflectionClass|string $reflection ReflectionClass instance or the fully qualified namespace of the DTO
      * to be converted into a ReflectionClass instance.
      * @throws \ReflectionException
      */
-    public function __construct(private ReflectionClass|string $reflection)
+    public function __construct(ReflectionClass|string $reflection)
     {
-        $this->reflection = is_string($this->reflection) ? new ReflectionClass($reflection) : $reflection;
+        $this->reflection = is_string($reflection) ? new ReflectionClass($reflection) : $reflection;
     }
 
     /**

--- a/src/Lib/Operation/ExceptionResponse.php
+++ b/src/Lib/Operation/ExceptionResponse.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 namespace SwaggerBake\Lib\Operation;
 
 use Cake\Core\Exception\CakeException;
+use Exception;
 use phpDocumentor\Reflection\DocBlock\Tags\Throws;
 use ReflectionClass;
-use ReflectionException;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\OpenApiExceptionSchemaInterface;
 use SwaggerBake\Lib\Swagger;
+use Throwable;
 
 /**
  * Defines an error responses.
@@ -50,6 +51,9 @@ class ExceptionResponse
         $exceptionFqn = $throw->getType()->__toString();
 
         try {
+            if (!class_exists($exceptionFqn)) {
+                throw new Exception("Class $exceptionFqn does not exist");
+            }
             $reflection = new ReflectionClass($exceptionFqn);
             if ($reflection->implementsInterface(OpenApiExceptionSchemaInterface::class)) {
                 $this->code = $exceptionFqn::getExceptionCode();
@@ -58,7 +62,7 @@ class ExceptionResponse
 
                 return $this;
             }
-        } catch (ReflectionException $e) {
+        } catch (Throwable $e) {
             $reflection = null;
         }
 

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -57,7 +57,11 @@ class OperationFromRouteFactory
         $docBlock = $this->getDocBlock($route);
 
         try {
-            $refClass = new ReflectionClass($route->getControllerFqn());
+            $fqn = $route->getControllerFqn();
+            if (!is_string($fqn) || !class_exists($fqn)) {
+                throw new Exception("Class $fqn does not exist");
+            }
+            $refClass = new ReflectionClass($fqn);
             $refMethod = $refClass->getMethod($route->getAction());
             $keys = (new Collection($refClass->getMethods()))->filter(function (ReflectionMethod $method) use ($route) {
                 return $route->getAction() == $method->getName();

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -69,14 +69,20 @@ class OperationFromRouteFactory
             $openApiOperation = null;
         }
 
+        /** @var \SwaggerBake\Lib\Attribute\OpenApiOperation|null $openApiOperation */
         if ($openApiOperation != null && !$openApiOperation->isVisible) {
             return null;
+        }
+
+        $sortOrder = key($keys ?? []);
+        if (!is_int($sortOrder)) {
+            $sortOrder = 100;
         }
 
         $operation = new Operation(
             operationId: $route->getName() . ':' . strtolower($httpMethod),
             httpMethod: $httpMethod,
-            sortOrder: key($keys ?? []) ?? 100
+            sortOrder: $sortOrder
         );
 
         $operation = $this->createOperation($operation, $route, $openApiOperation);

--- a/src/Lib/Operation/OperationRequestBody.php
+++ b/src/Lib/Operation/OperationRequestBody.php
@@ -165,7 +165,7 @@ class OperationRequestBody
         if ($openApiSchema instanceof OpenApiSchema) {
             $schema = $openApiSchema->createSchema();
         } else {
-            $schema = (new Schema())->setVisibility(OpenApiSchema::VISIBILE_NEVER);
+            $schema = (new Schema())->setVisibility(OpenApiSchema::VISIBLE_NEVER);
         }
 
         $schema

--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -155,7 +155,7 @@ class OperationResponse
                 if ($openApiSchema instanceof OpenApiSchema) {
                     $schema->setVisibility($openApiSchema->visibility);
                 } else {
-                    $schema->setVisibility(OpenApiSchema::VISIBILE_NEVER);
+                    $schema->setVisibility(OpenApiSchema::VISIBLE_NEVER);
                 }
             // create base schema from attributes only
             } else {
@@ -163,7 +163,7 @@ class OperationResponse
                 if ($openApiSchema instanceof OpenApiSchema) {
                     $schema = $openApiSchema->createSchema();
                 } else {
-                    $schema = (new Schema())->setVisibility(OpenApiSchema::VISIBILE_NEVER);
+                    $schema = (new Schema())->setVisibility(OpenApiSchema::VISIBLE_NEVER);
                 }
             }
 

--- a/src/Lib/Operation/OperationSecurity.php
+++ b/src/Lib/Operation/OperationSecurity.php
@@ -96,14 +96,10 @@ class OperationSecurity
         $scheme = array_keys($array['components']['securitySchemes'])[0];
 
         $securities = $this->operation->getSecurity();
-        if (array_key_exists($scheme, $securities)) {
+        if (array_key_exists($scheme, $securities) || !is_string($scheme)) {
             return;
         }
 
-        $this->operation->pushSecurity(
-            (new PathSecurity())
-                ->setName($scheme)
-                ->setScopes([])
-        );
+        $this->operation->pushSecurity(new PathSecurity($scheme));
     }
 }

--- a/src/Lib/PathFromRouteFactory.php
+++ b/src/Lib/PathFromRouteFactory.php
@@ -46,7 +46,7 @@ class PathFromRouteFactory
             return $path;
         }
 
-        /** @var OpenApiPath|null $openApiPath */
+        /** @var \SwaggerBake\Lib\Attribute\OpenApiPath|null $openApiPath */
         $openApiPath = (new AttributeFactory($reflection, OpenApiPath::class))->createOneOrNull();
         if ($openApiPath instanceof OpenApiPath && !$openApiPath->isVisible) {
             return null;

--- a/src/Lib/PathFromRouteFactory.php
+++ b/src/Lib/PathFromRouteFactory.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Lib;
 
-use Exception;
 use ReflectionClass;
 use SwaggerBake\Lib\Attribute\AttributeFactory;
 use SwaggerBake\Lib\Attribute\OpenApiPath;
@@ -34,17 +33,12 @@ class PathFromRouteFactory
         }
 
         $fqn = $this->route->getControllerFqn();
-        if (is_null($fqn)) {
+        if (is_null($fqn) || !class_exists($fqn)) {
             return null;
         }
 
         $path = new Path($this->route->templateToOpenApiPath());
-
-        try {
-            $reflection = new ReflectionClass($fqn);
-        } catch (Exception) {
-            return $path;
-        }
+        $reflection = new ReflectionClass($fqn);
 
         /** @var \SwaggerBake\Lib\Attribute\OpenApiPath|null $openApiPath */
         $openApiPath = (new AttributeFactory($reflection, OpenApiPath::class))->createOneOrNull();

--- a/src/Lib/PathFromRouteFactory.php
+++ b/src/Lib/PathFromRouteFactory.php
@@ -46,6 +46,7 @@ class PathFromRouteFactory
             return $path;
         }
 
+        /** @var OpenApiPath|null $openApiPath */
         $openApiPath = (new AttributeFactory($reflection, OpenApiPath::class))->createOneOrNull();
         if ($openApiPath instanceof OpenApiPath && !$openApiPath->isVisible) {
             return null;

--- a/src/Lib/Route/RouteScanner.php
+++ b/src/Lib/Route/RouteScanner.php
@@ -102,7 +102,10 @@ class RouteScanner
         });
 
         if (count($results) === 1) {
-            $routeDecorator->setControllerFqn('\\' . reset($results));
+            $fqn = reset($results);
+            if (is_string($fqn) && class_exists($fqn)) {
+                $routeDecorator->setControllerFqn("\\$fqn");
+            }
         }
 
         return $routeDecorator;

--- a/src/Lib/Schema/SchemaFactory.php
+++ b/src/Lib/Schema/SchemaFactory.php
@@ -55,13 +55,14 @@ class SchemaFactory
         $reflection = new ReflectionClass($modelDecorator->getModel()->getEntity());
         $openApiSchema = (new AttributeFactory($reflection, OpenApiSchema::class))->createOneOrNull();
 
-        if ($openApiSchema instanceof OpenApiSchema && $openApiSchema->visibility === OpenApiSchema::VISIBILE_NEVER) {
+        /** @var \SwaggerBake\Lib\Attribute\OpenApiSchema $openApiSchema */
+        if ($openApiSchema instanceof OpenApiSchema && $openApiSchema->visibility === OpenApiSchema::VISIBLE_NEVER) {
             return null;
         }
 
         $schema = $this
             ->createSchema($modelDecorator->getModel(), $propertyType)
-            ->setVisibility($openApiSchema->visibility ?? OpenApiSchema::VISIBILE_DEFAULT)
+            ->setVisibility($openApiSchema->visibility ?? OpenApiSchema::VISIBLE_DEFAULT)
             ->setDescription($openApiSchema->description ?? '');
 
         EventManager::instance()->dispatch(

--- a/src/Lib/Schema/SchemaPropertyValidation.php
+++ b/src/Lib/Schema/SchemaPropertyValidation.php
@@ -290,7 +290,7 @@ class SchemaPropertyValidation
     private function defineMinItems()
     {
         $result = $this->getValidationRuleValueFromClosure('hasAtLeast');
-        if (is_numeric($result)) {
+        if (is_int($result)) {
             $this->schemaProperty->setMinItems($result);
         }
 
@@ -304,7 +304,7 @@ class SchemaPropertyValidation
     private function defineMaxItems()
     {
         $result = $this->getValidationRuleValueFromClosure('hasAtMost');
-        if (is_numeric($result)) {
+        if (is_int($result)) {
             $this->schemaProperty->setMaxItems($result);
         }
 

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -111,9 +111,9 @@ class Swagger
     /**
      * Returns OpenAPI 3.0 spec as a JSON string
      *
-     * @return false|string
+     * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         $this->addAdditionalSchema();
 
@@ -121,7 +121,12 @@ class Swagger
             new Event('SwaggerBake.beforeRender', $this)
         );
 
-        return json_encode($this->getArray(), $this->config->get('jsonOptions'));
+        $json = json_encode($this->getArray(), $this->config->get('jsonOptions'));
+        if (!$json) {
+            throw new SwaggerBakeRunTimeException('Error converting OpenAPI to JSON.');
+        }
+
+        return $json;
     }
 
     /**
@@ -249,7 +254,7 @@ class Swagger
             return $content;
         }
 
-        if (in_array($schema->getVisibility(), [OpenApiSchema::VISIBILE_ALWAYS, OpenApiSchema::VISIBILE_DEFAULT])) {
+        if (in_array($schema->getVisibility(), [OpenApiSchema::VISIBLE_ALWAYS, OpenApiSchema::VISIBLE_DEFAULT])) {
             $schema->setRefPath('#/components/schemas/' . $schema->getName());
             if ($schema->getType() == 'array') {
                 $schema->setType('object');

--- a/tests/TestCase/Lib/Attribute/OpenApiSchemaTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiSchemaTest.php
@@ -68,7 +68,7 @@ class OpenApiSchemaTest extends TestCase
     }
 
     /**
-     * @see OpenApiSchema::VISIBILE_NEVER
+     * @see OpenApiSchema::VISIBLE_NEVER
      */
     public function test_schema_never_visible(): void
     {
@@ -83,7 +83,7 @@ class OpenApiSchemaTest extends TestCase
     }
 
     /**
-     * @see OpenApiSchema::VISIBILE_HIDDEN
+     * @see OpenApiSchema::VISIBLE_HIDDEN
      */
     public function test_schema_is_hidden(): void
     {

--- a/tests/TestCase/Lib/MediaType/HalJsonTest.php
+++ b/tests/TestCase/Lib/MediaType/HalJsonTest.php
@@ -11,6 +11,8 @@ use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\Factory\SwaggerFactory;
 use SwaggerBake\Lib\MediaType\HalJson;
 use SwaggerBake\Lib\Model\ModelScanner;
+use SwaggerBake\Lib\OpenApi\Schema;
+use SwaggerBake\Lib\OpenApi\SchemaProperty;
 use SwaggerBake\Lib\Operation\OperationResponseAssociation;
 use SwaggerBake\Lib\Route\RouteScanner;
 use SwaggerBake\Lib\Swagger;
@@ -124,5 +126,34 @@ class HalJsonTest extends TestCase
                 return isset($item['$ref']) && $item['$ref'] == '#/x-swagger-bake/components/schemas/DepartmentEmployee';
             })
         );
+    }
+
+    public function test_nested_associations(): void
+    {
+        $schema = new Schema();
+        $schema->setProperties([
+            (new SchemaProperty())
+                ->setType('string')
+                ->setName('test_string'),
+            (new SchemaProperty())
+                ->setType('object')
+                ->setName('test_ref_entity')
+                ->setRefEntity('#/components/schemas/TestEntity'),
+            (new Schema())
+                ->setType('object')
+                ->setName('test_object')
+                ->setProperties([
+                    (new SchemaProperty())
+                        ->setType('string')->setName('test_string')
+                ])
+        ]);
+
+        $schema = (new HalJson())->buildSchema($schema, 'object');
+        $object = json_decode(json_encode($schema->jsonSerialize()));
+
+        $this->assertObjectHasAttribute('test_string', $object->items->properties);
+        $this->assertObjectHasAttribute('test_ref_entity', $object->items->properties->_embedded->properties);
+        $this->assertCount(2, $object->items->properties->_embedded->properties->test_ref_entity->allOf);
+        $this->assertObjectHasAttribute('test_object', $object->items->properties->_embedded->properties);
     }
 }

--- a/tests/TestCase/Lib/Operation/OperationRequestBodyTest.php
+++ b/tests/TestCase/Lib/Operation/OperationRequestBodyTest.php
@@ -157,7 +157,7 @@ class OperationRequestBodyTest extends TestCase
             $this->assertTrue($schema->isCustomSchema());
 
             if ($class == EmployeeDataRequestPublicSchemaLegacy::class) {
-                $this->assertEquals(OpenApiSchema::VISIBILE_DEFAULT, $schema->getVisibility());
+                $this->assertEquals(OpenApiSchema::VISIBLE_DEFAULT, $schema->getVisibility());
             }
 
             $properties = $schema->getProperties();
@@ -228,7 +228,7 @@ class OperationRequestBodyTest extends TestCase
             $this->assertTrue($schema->isCustomSchema());
 
             if ($class == EmployeeDataRequestPublicSchemaLegacy::class) {
-                $this->assertEquals(OpenApiSchema::VISIBILE_DEFAULT, $schema->getVisibility());
+                $this->assertEquals(OpenApiSchema::VISIBLE_DEFAULT, $schema->getVisibility());
             }
 
             $properties = $schema->getProperties();

--- a/tests/TestCase/Lib/Operation/OperationResponseTest.php
+++ b/tests/TestCase/Lib/Operation/OperationResponseTest.php
@@ -549,7 +549,7 @@ class OperationResponseTest extends TestCase
             ->getSchema();
 
         if ($class == CustomResponseSchemaPublic::class) {
-            $this->assertEquals(OpenApiSchema::VISIBILE_DEFAULT, $schema->getVisibility());
+            $this->assertEquals(OpenApiSchema::VISIBLE_DEFAULT, $schema->getVisibility());
         }
 
         $this->assertEquals($schemaType, $schema->getType());

--- a/tests/TestCase/Lib/PathFromRouteFactoryTest.php
+++ b/tests/TestCase/Lib/PathFromRouteFactoryTest.php
@@ -67,7 +67,7 @@ class PathFromRouteFactoryTest extends TestCase
         $this->assertEquals('/employees', $path->getResource());
     }
 
-    public function test_create_returning_null_on_empty_http_methods(): void
+    public function test_create_returns_null_on_empty_http_methods(): void
     {
         $decorator = new RouteDecorator(new Route('/template', []));
         $decorator->setControllerFqn('\App\Controller\EmployeesController');
@@ -75,18 +75,17 @@ class PathFromRouteFactoryTest extends TestCase
         $this->assertNull($path->create());
     }
 
-    public function test_create_returning_null_on_null_controller(): void
+    public function test_create_returns_null_when_controller_does_not_exist(): void
     {
+        // null controller should return null
         $decorator = new RouteDecorator(new Route('/template', ['_method' => 'GET']));
         $path = new PathFromRouteFactory($decorator);
         $this->assertNull($path->create());
-    }
 
-    public function test_create_returning_path_on_reflection_exception(): void
-    {
+        // class does not exist should return null
         $decorator = new RouteDecorator(new Route('/template', ['_method' => 'GET']));
         $decorator->setControllerFqn('\App\Controller\Nope');
         $path = new PathFromRouteFactory($decorator);
-        $this->assertInstanceOf(Path::class, $path->create());
+        $this->assertNull($path->create());
     }
 }

--- a/tests/test_app/src/Model/Entity/DepartmentEmployee.php
+++ b/tests/test_app/src/Model/Entity/DepartmentEmployee.php
@@ -17,7 +17,7 @@ use SwaggerBake\Lib\Attribute\OpenApiSchema;
  * @property \SwaggerBake\Test\Model\Entity\Employee $employee
  * @property \SwaggerBake\Test\Model\Entity\Department $department
  */
-#[OpenApiSchema(visibility: OpenApiSchema::VISIBILE_HIDDEN)]
+#[OpenApiSchema(visibility: OpenApiSchema::VISIBLE_HIDDEN)]
 class DepartmentEmployee extends Entity
 {
     /**


### PR DESCRIPTION
- Sets PHPStan to level 7
- Fixes misspelling in OpenApiSchema visibility constants, deprecates old misspelled constants.