### PR TITLE
Plugin routes not showing due to namespace collision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["cakephp swagger","cakephp4 swagger","cake swagger"],
     "require": {
         "php": "^8.0",
-        "cakephp/cakephp": "4.4.0-RC1",
+        "cakephp/cakephp": "^4.2",
         "symfony/yaml": "^5.0",
         "phpdocumentor/reflection-docblock": "^5.1",
         "thecodingmachine/class-explorer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "psr-4": {
             "SwaggerBake\\Test\\": "tests/",
             "SwaggerBakeTest\\App\\": "tests/test_app/src/",
+            "Demo\\": "tests/test_app/plugins/Demo/src/",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["cakephp swagger","cakephp4 swagger","cake swagger"],
     "require": {
         "php": "^8.0",
-        "cakephp/cakephp": "^4.2",
+        "cakephp/cakephp": "4.4.0-RC1",
         "symfony/yaml": "^5.0",
         "phpdocumentor/reflection-docblock": "^5.1",
         "thecodingmachine/class-explorer": "^1.1",

--- a/src/Controller/SwaggerController.php
+++ b/src/Controller/SwaggerController.php
@@ -3,10 +3,8 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Controller;
 
-use SwaggerBake\Controller\Component\SwaggerUiComponent;
-
 /**
- * @property SwaggerUiComponent $SwaggerUi
+ * @property \SwaggerBake\Controller\Component\SwaggerUiComponent $SwaggerUi
  */
 class SwaggerController extends AppController
 {

--- a/src/Controller/SwaggerController.php
+++ b/src/Controller/SwaggerController.php
@@ -3,15 +3,16 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Controller;
 
+use SwaggerBake\Controller\Component\SwaggerUiComponent;
+
+/**
+ * @property SwaggerUiComponent $SwaggerUi
+ */
 class SwaggerController extends AppController
 {
     /**
-     * @var \SwaggerBake\Controller\Component\SwaggerUiComponent
-     */
-    public $SwaggerUi;
-
-    /**
      * @return void
+     * @throws \Exception
      */
     public function initialize(): void
     {

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -175,8 +175,11 @@ class OperationFromRouteFactory
         }
 
         if (!count($operation->getTags())) {
+            $tag = $route->getPlugin() ?? '';
+            $tag .= ' ' . Inflector::humanize(Inflector::underscore($route->getController()));
+
             $operation->setTags([
-                Inflector::humanize(Inflector::underscore($route->getController())),
+                trim($tag),
             ]);
         }
 

--- a/src/Lib/Route/RouteDecorator.php
+++ b/src/Lib/Route/RouteDecorator.php
@@ -297,6 +297,10 @@ class RouteDecorator
         $fqn .= $this->prefix ? $this->prefix . '\\' : '';
         $fqn .= $this->controller . 'Controller';
 
+        if (!class_exists($fqn)) {
+            return null;
+        }
+
         return $fqn;
     }
 }

--- a/tests/TestCase/Lib/Route/RouteDecoratorTest.php
+++ b/tests/TestCase/Lib/Route/RouteDecoratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SwaggerBake\Test\TestCase\Lib\Route;
+
+use Cake\Routing\Route\Route;
+use Cake\TestSuite\TestCase;
+use SwaggerBake\Lib\Route\RouteDecorator;
+
+class RouteDecoratorTest extends TestCase
+{
+    public function test_construct(): void
+    {
+        $defaults = [
+            'plugin' => null,
+            'prefix' => null,
+            'controller' => 'Test',
+            'action' => 'index',
+            '_method' => 'GET'
+        ];
+
+        // App controller
+        $routeDecorator = (new RouteDecorator(new Route('/test/template', $defaults)));
+        $this->assertEquals($defaults['plugin'], $routeDecorator->getPlugin());
+        $this->assertEquals($defaults['prefix'], $routeDecorator->getPrefix());
+        $this->assertEquals($defaults['controller'], $routeDecorator->getController());
+        $this->assertEquals($defaults['action'], $routeDecorator->getAction());
+        $this->assertEquals([$defaults['_method']], $routeDecorator->getMethods());
+        $this->assertEquals([$defaults['_method']], $routeDecorator->getMethods());
+        $this->assertEquals('SwaggerBakeTest\App\Controller\TestController', $routeDecorator->getControllerFqn());
+
+        // Plugin controller + multiple methods
+        $defaults['plugin'] = 'TestPlugin';
+        $defaults['_method'] = ['GET', 'POST'];
+        $routeDecorator = (new RouteDecorator(new Route('/test/template', $defaults)));
+        $this->assertEquals($defaults['plugin'], $routeDecorator->getPlugin());
+        $this->assertEquals($defaults['_method'], $routeDecorator->getMethods());
+        $this->assertEquals('TestPlugin\Controller\TestController', $routeDecorator->getControllerFqn());
+    }
+}

--- a/tests/TestCase/Lib/Route/RouteDecoratorTest.php
+++ b/tests/TestCase/Lib/Route/RouteDecoratorTest.php
@@ -13,7 +13,7 @@ class RouteDecoratorTest extends TestCase
         $defaults = [
             'plugin' => null,
             'prefix' => null,
-            'controller' => 'Test',
+            'controller' => 'Departments',
             'action' => 'index',
             '_method' => 'GET'
         ];
@@ -25,15 +25,21 @@ class RouteDecoratorTest extends TestCase
         $this->assertEquals($defaults['controller'], $routeDecorator->getController());
         $this->assertEquals($defaults['action'], $routeDecorator->getAction());
         $this->assertEquals([$defaults['_method']], $routeDecorator->getMethods());
-        $this->assertEquals([$defaults['_method']], $routeDecorator->getMethods());
-        $this->assertEquals('SwaggerBakeTest\App\Controller\TestController', $routeDecorator->getControllerFqn());
+        $this->assertEquals(
+            'SwaggerBakeTest\App\Controller\DepartmentsController',
+            $routeDecorator->getControllerFqn()
+        );
 
         // Plugin controller + multiple methods
-        $defaults['plugin'] = 'TestPlugin';
+        $defaults['plugin'] = 'Demo';
         $defaults['_method'] = ['GET', 'POST'];
+        $defaults['controller'] = 'Test';
         $routeDecorator = (new RouteDecorator(new Route('/test/template', $defaults)));
         $this->assertEquals($defaults['plugin'], $routeDecorator->getPlugin());
         $this->assertEquals($defaults['_method'], $routeDecorator->getMethods());
-        $this->assertEquals('TestPlugin\Controller\TestController', $routeDecorator->getControllerFqn());
+        $this->assertEquals(
+            'Demo\Controller\TestController',
+            $routeDecorator->getControllerFqn()
+        );
     }
 }

--- a/tests/TestCase/Lib/Route/RouteScannerTest.php
+++ b/tests/TestCase/Lib/Route/RouteScannerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SwaggerBake\Test\TestCase\Lib\Route;
+
+use Cake\Routing\Router;
+use Cake\TestSuite\TestCase;
+use SwaggerBake\Lib\Configuration;
+use SwaggerBake\Lib\Route\RouteScanner;
+
+class RouteScannerTest extends TestCase
+{
+    public function test_construct_throws_invalid_arg_exception_when_prefix_invalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new RouteScanner(new Router(), new Configuration(['prefix' => '']));
+    }
+}

--- a/tests/test_app/plugins/Demo/src/Controller/TestController.php
+++ b/tests/test_app/plugins/Demo/src/Controller/TestController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Demo\Controller;
+
+use SwaggerBake\Lib\Attribute\OpenApiResponse;
+
+class TestController
+{
+    /**
+     * Just an example of a plugin.
+     *
+     * @return \Cake\Http\Response
+     */
+    #[OpenApiResponse(description: 'demo', mimeTypes: ['text/plain'])]
+    public function index()
+    {
+
+    }
+}

--- a/tests/test_app/plugins/Demo/src/Plugin.php
+++ b/tests/test_app/plugins/Demo/src/Plugin.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Demo;
+
+use Cake\Core\BasePlugin;
+use Cake\Core\PluginApplicationInterface;
+use Cake\Http\MiddlewareQueue;
+use Cake\Routing\RouteBuilder;
+use Cake\Console\CommandCollection;
+
+/**
+ * Plugin for Demo
+ */
+class Plugin extends BasePlugin
+{
+    /**
+     * Load all the plugin configuration and bootstrap logic.
+     *
+     * The host application is provided as an argument. This allows you to load
+     * additional plugin dependencies, or attach events.
+     *
+     * @param \Cake\Core\PluginApplicationInterface $app The host application
+     * @return void
+     */
+    public function bootstrap(PluginApplicationInterface $app): void
+    {
+    }
+
+    /**
+     * Add routes for the plugin.
+     *
+     * If your plugin has many routes and you would like to isolate them into a separate file,
+     * you can create `$plugin/config/routes.php` and delete this method.
+     *
+     * @param \Cake\Routing\RouteBuilder $routes The route builder to update.
+     * @return void
+     */
+    public function routes(RouteBuilder $routes): void
+    {
+        $routes->plugin(
+            'Demo',
+            ['path' => '/demo'],
+            function (RouteBuilder $builder) {
+                // Add custom routes here
+                $builder->setExtensions(['json','xml']);
+                $builder->resources('Test', ['only' => 'index']);
+                $builder->fallbacks();
+            }
+        );
+        parent::routes($routes);
+    }
+
+    /**
+     * Add middleware for the plugin.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middleware The middleware queue to update.
+     * @return \Cake\Http\MiddlewareQueue
+     */
+    public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
+    {
+        // Add your middlewares here
+
+        return $middlewareQueue;
+    }
+
+    /**
+     * Add commands for the plugin.
+     *
+     * @param \Cake\Console\CommandCollection $commands The command collection to update.
+     * @return \Cake\Console\CommandCollection
+     */
+    public function console(CommandCollection $commands) : CommandCollection
+    {
+        // Add your commands here
+
+        $commands = parent::console($commands);
+
+        return $commands;
+    }
+}


### PR DESCRIPTION
Reference: #399

This PR does two things:
- Sets the base namespace for a controller to either the plugin name or the value of `App.namespace` in the RouteScanner. This resolves the issue reported by @aginev
- Conditionally prefixes the plugin name to the OpenAPI tag (if the controller belongs to a plugin).
 