### PR TITLE
Entity mass assignment support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "symfony/yaml": "^5.0",
         "phpdocumentor/reflection-docblock": "^5.1",
         "thecodingmachine/class-explorer": "^1.1",
-        "mixerapi/core": "^0.2 || ^1.0"
+        "mixerapi/core": "^1.1.1"
     },
     "suggest": {
         "cakephp/authentication": "Used by SwaggerBake #[OpenApiSecurity]",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "symfony/yaml": "^5.0",
         "phpdocumentor/reflection-docblock": "^5.1",
         "thecodingmachine/class-explorer": "^1.1",
-        "mixerapi/core": "^1.1.1"
+        "mixerapi/core": "^1.1.2"
     },
     "suggest": {
         "cakephp/authentication": "Used by SwaggerBake #[OpenApiSecurity]",

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -297,8 +297,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
     }
 
     /**
-     * @param bool $isHidden
-     *
+     * @param bool $isHidden Is this property in Entity::_hidden?
      * @return $this
      */
     public function setIsHidden(bool $isHidden)

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -33,6 +33,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
     private bool $isReadOnly = false;
     private bool $isWriteOnly = false;
     private bool $isRequired = false;
+    private bool $isHidden = false;
     private bool $requirePresenceOnCreate = false;
     private bool $requirePresenceOnUpdate = false;
     private array $items = [];
@@ -69,7 +70,9 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
     {
         $vars = get_object_vars($this);
 
-        // rename class properties to match openapi schema
+        /*
+         * rename class properties to match openapi schema
+         */
         foreach (self::PROPERTIES_TO_OPENAPI_SPEC as $classProperty => $openApiProperty) {
             if (isset($vars[$classProperty])) {
                 $vars[$openApiProperty] = $vars[$classProperty];
@@ -77,17 +80,21 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             }
         }
 
-        // remove internal properties
+        /*
+         * remove internal properties
+         */
         $vars = ArrayUtility::removeKeysMatching(
             $vars,
-            ['name','isRequired','requirePresenceOnCreate','requirePresenceOnUpdate','refEntity']
+            ['name','isRequired','requirePresenceOnCreate','requirePresenceOnUpdate','refEntity', 'isHidden']
         );
 
         if (!empty($this->refEntity)) {
             $vars['$ref'] = $this->refEntity;
         }
 
-        // Removing empty and null items from OpenAPI
+        /*
+         * remove empty and null items from OpenAPI
+         */
         $vars = ArrayUtility::removeEmptyVars(
             $vars,
             [
@@ -97,10 +104,14 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             ]
         );
 
-        // Remove null values
+        /*
+         * remove null values
+         */
         $vars = ArrayUtility::removeNullValues($vars, ['example']);
 
-        // Remove items matching their defaults from OpenAPI
+        /*
+         * remove items matching their defaults from OpenAPI
+         */
         $vars = ArrayUtility::removeValuesMatching(
             $vars,
             ['readOnly' => false, 'writeOnly' => false, 'deprecated' => false, 'nullable' => false]
@@ -273,6 +284,26 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
     public function setRefEntity(string $refEntity)
     {
         $this->refEntity = $refEntity;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHidden(): bool
+    {
+        return $this->isHidden;
+    }
+
+    /**
+     * @param bool $isHidden
+     *
+     * @return $this
+     */
+    public function setIsHidden(bool $isHidden)
+    {
+        $this->isHidden = $isHidden;
 
         return $this;
     }

--- a/src/Lib/Schema/SchemaFactory.php
+++ b/src/Lib/Schema/SchemaFactory.php
@@ -138,12 +138,25 @@ class SchemaFactory
 
         $return = array_merge($return, $this->getPropertyAnnotations($model));
 
+        /*
+         * Return all properties excluding hidden properties that are not available for writing
+         */
         if ($propertyType === self::ALL_PROPERTIES) {
-            return $return;
+            return array_filter($return, function (SchemaProperty $property) {
+                if (!$property->isWriteOnly() && $property->isHidden()) {
+                    return false;
+                }
+                return true;
+            });
         }
 
+        /*
+         * Return properties depending on requested property type:
+         * - readable: when property is not write only and not hidden
+         * - writeable: when property is not read only
+         */
         return array_filter($return, function (SchemaProperty $property) use ($propertyType) {
-            if ($propertyType == self::READABLE_PROPERTIES && !$property->isWriteOnly()) {
+            if ($propertyType == self::READABLE_PROPERTIES && !$property->isWriteOnly() && !$property->isHidden()) {
                 return true;
             }
             if ($propertyType == self::WRITEABLE_PROPERTIES && !$property->isReadOnly()) {

--- a/src/Lib/Schema/SchemaFactory.php
+++ b/src/Lib/Schema/SchemaFactory.php
@@ -146,6 +146,7 @@ class SchemaFactory
                 if (!$property->isWriteOnly() && $property->isHidden()) {
                     return false;
                 }
+
                 return true;
             });
         }

--- a/tests/Fixture/EmployeesFixture.php
+++ b/tests/Fixture/EmployeesFixture.php
@@ -18,11 +18,14 @@ class EmployeesFixture extends TestFixture
     // phpcs:disable
     public $fields = [
         'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
-        'birth_date' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
         'first_name' => ['type' => 'string', 'length' => 14, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
         'last_name' => ['type' => 'string', 'length' => 16, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
         'gender' => ['type' => 'string', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
         'hire_date' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'birth_date' => ['type' => 'date', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'write' => ['type' => 'string', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
+        'read' => ['type' => 'string', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
+        'hide' => ['type' => 'string', 'length' => null, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
         ],
@@ -42,11 +45,14 @@ class EmployeesFixture extends TestFixture
         $this->records = [
             [
                 'id' => 1,
-                'birth_date' => '2020-04-09',
                 'first_name' => 'Lorem ipsum ',
                 'last_name' => 'Lorem ipsum do',
                 'gender' => 'Lorem ipsum dolor sit amet',
+                'birth_date' => '2020-04-09',
                 'hire_date' => '2020-04-09',
+                'write' => 'wo',
+                'read' => 'ro',
+                'hide' => 'hidden',
             ],
         ];
         parent::init();

--- a/tests/TestCase/Lib/SwaggerSchemaTest.php
+++ b/tests/TestCase/Lib/SwaggerSchemaTest.php
@@ -57,16 +57,31 @@ class SwaggerSchemaTest extends TestCase
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
         $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
-
         $arr = json_decode($swagger->toString(), true);
 
         $this->assertArrayHasKey('Employee', $arr['components']['schemas']);
         $employee = $arr['components']['schemas']['Employee'];
-        
+
         $this->assertArrayHasKey('birth_date', $employee['properties']);
 
         $this->assertTrue($employee['properties']['id']['readOnly']);
         $this->assertEquals('integer', $employee['properties']['id']['type']);
+        $this->assertEquals('int64', $employee['properties']['id']['format']);
+
+
+        $this->assertEquals('date', $employee['properties']['birth_date']['format']);
+        $this->assertIsArray($employee['properties']['gender']['enum']);
+        $this->assertEquals('date', $employee['properties']['hire_date']['format']);
+
+        $this->assertTrue($employee['properties']['read']['readOnly']);
+        $this->assertTrue($employee['properties']['write']['writeOnly']);
+        $this->assertArrayNotHasKey('hide', $employee['properties']);
+
+        foreach (['birth_date', 'first_name', 'last_name', 'gender', 'hire_date',] as $property) {
+            $this->assertEquals('string', $employee['properties'][$property]['type'], "$property is not string");
+            $this->assertTrue(!isset($employee['properties'][$property]['readOnly']), "$property should !readOnly");
+            $this->assertTrue(!isset($employee['properties'][$property]['writeOnly']), "$property should !writeOnly");
+        }
     }
 
     public function test_yml_schema_takes_precedence(): void

--- a/tests/test_app/src/Model/Entity/Employee.php
+++ b/tests/test_app/src/Model/Entity/Employee.php
@@ -7,7 +7,7 @@ use Cake\ORM\Entity;
 use SwaggerBake\Lib\Attribute\OpenApiSchemaProperty;
 
 #[OpenApiSchemaProperty(name: 'gender', example: 'female', enum: ['male','female','other'])]
-#[OpenApiSchemaProperty(name: 'last_name', maxLength: 59, minLength: 3, pattern: '/\W/')]
+#[OpenApiSchemaProperty(name: 'last_name', minLength: 3, maxLength: 59, pattern: '/\W/')]
 class Employee extends Entity
 {
     /**
@@ -20,13 +20,16 @@ class Employee extends Entity
      * @var array
      */
     protected $_accessible = [
-        'birth_date' => true,
         'first_name' => true,
         'last_name' => true,
         'gender' => true,
         'hire_date' => true,
-        'department_employees' => true,
-        'employee_salaries' => true,
-        'employee_titles' => true,
+        'birth_date' => true,
+        'write' => true,
+        '*' => false
+    ];
+
+    protected $_hidden = [
+        'hide', 'write'
     ];
 }


### PR DESCRIPTION
Adds support for [Entity](https://book.cakephp.org/4/en/orm/entities.html) `$_accessible` and `$_hidden` properties and will now properly set OpenAPI writeOnly and readOnly properties.

- readOnly when not accessible and not hidden.
- writeOnly when accessible and is hidden.
- never display properties when is not accessible and is hidden.