### PR TITLE
breaking change to remove config loading from plugin bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ use the manual setup.
 
 ### Automated Setup
 
-Run the install command and then [add a route](#add-route).
+Run the installer: 
 
 ```console
 bin/cake swagger install
 ```
+
+Then [load the config](#load-the-config) and [add a route](#add-route).
 
 ### Manual Setup
 
@@ -89,6 +91,14 @@ file [here](assets/swagger_bake.php) for further explanation. Then just [add a r
 
 For more read sections on [Multiple Instances of SwaggerBake](#multiple-instances-of-swagger-bake) 
 and [Extending Views and Controllers](#extending-views-and-controllers)
+
+### Load the config
+
+In your `config/bootstrap.php` file:
+
+```php
+Configure::load('app', 'default', false);
+```
 
 ### Add Route
 

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -70,7 +70,9 @@ class InstallCommand extends Command
             }
         } while ($installComplete != true);
 
-        $io->out("Now just add a route in your config/routes.php for SwaggerUI and you're ready to go!");
+        $io->out("Just a few more steps:");
+        $io->out("1. Load the swagger_bake.php config in your config/bootstrap.");
+        $io->out("2. Add a route in your config/routes.php to the SwaggerBake controller.");
 
         $io->success('Installation Complete!');
     }

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -70,9 +70,9 @@ class InstallCommand extends Command
             }
         } while ($installComplete != true);
 
-        $io->out("Just a few more steps:");
-        $io->out("1. Load the swagger_bake.php config in your config/bootstrap.");
-        $io->out("2. Add a route in your config/routes.php to the SwaggerBake controller.");
+        $io->out('Just a few more steps:');
+        $io->out('1. Load the swagger_bake.php config in your config/bootstrap.');
+        $io->out('2. Add a route in your config/routes.php to the SwaggerBake controller.');
 
         $io->success('Installation Complete!');
     }

--- a/src/Lib/Configuration.php
+++ b/src/Lib/Configuration.php
@@ -95,6 +95,7 @@ class Configuration
     public function __construct(array $config = [], string $root = ROOT)
     {
         $this->root = $root;
+        Configure::load('swagger_bake', 'default');
         $config = !empty($config) ? $config : Configure::read('SwaggerBake');
 
         foreach (['yml', 'json', 'webPath', 'prefix'] as $property) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,7 +5,6 @@ namespace SwaggerBake;
 
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
-use Cake\Core\Configure;
 use Cake\Core\ContainerInterface;
 use Cake\Core\PluginApplicationInterface;
 use SwaggerBake\Command as Commands;
@@ -43,7 +42,6 @@ class Plugin extends BasePlugin
      */
     public function bootstrap(PluginApplicationInterface $app): void
     {
-        Configure::load('swagger_bake', 'default');
         ExtensionLoader::load();
     }
 


### PR DESCRIPTION
Loading the config in bootstrap breaks the installer and probably shouldn't have done in the first place. This will be a breaking change and users must now manually load the config in their `config/bootstrap.php`.