### PR TITLE
Make sure controller name is uppercase so the fqm is located in the c…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,11 @@
         "wiki": "https://github.com/cnizzardini/cakephp-swagger-bake/wiki",
         "source": "https://github.com/cnizzardini/cakephp-swagger-bake"
     },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": false
+        }
+    },
     "authors": [
         {
             "name": "Chris Nizzardini",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": false
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "authors": [

--- a/src/Controller/SwaggerController.php
+++ b/src/Controller/SwaggerController.php
@@ -7,6 +7,7 @@ class SwaggerController extends AppController
 {
     /**
      * @var \SwaggerBake\Controller\Component\SwaggerUiComponent
+     * @SuppressWarnings(PHPMD.CamelCasePropertyName)
      */
     public $SwaggerUi;
 

--- a/src/Controller/SwaggerController.php
+++ b/src/Controller/SwaggerController.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace SwaggerBake\Controller;
 
+/**
+ * @SuppressWarnings(PHPMD)
+ */
 class SwaggerController extends AppController
 {
     /**
      * @var \SwaggerBake\Controller\Component\SwaggerUiComponent
-     * @SuppressWarnings(PHPMD)
      */
     public $SwaggerUi;
 

--- a/src/Controller/SwaggerController.php
+++ b/src/Controller/SwaggerController.php
@@ -7,7 +7,7 @@ class SwaggerController extends AppController
 {
     /**
      * @var \SwaggerBake\Controller\Component\SwaggerUiComponent
-     * @SuppressWarnings(PHPMD.CamelCasePropertyName)
+     * @SuppressWarnings(PHPMD)
      */
     public $SwaggerUi;
 

--- a/src/Controller/SwaggerController.php
+++ b/src/Controller/SwaggerController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace SwaggerBake\Controller;
 
 /**
- * @SuppressWarnings(PHPMD)
+ * @SuppressWarnings(PHPMD.CamelCasePropertyName)
  */
 class SwaggerController extends AppController
 {

--- a/src/Lib/Route/RouteScanner.php
+++ b/src/Lib/Route/RouteScanner.php
@@ -92,7 +92,7 @@ class RouteScanner
             $routeDecorator = new RouteDecorator($route);
             $path = 'Controller\\';
             $path .= $routeDecorator->getPrefix() ? $routeDecorator->getPrefix() . '\\' : '';
-            $path .= $routeDecorator->getController() . 'Controller';
+            $path .= ucfirst($routeDecorator->getController()) . 'Controller';
 
             $results = array_filter($classes, function ($fqn) use ($path) {
                 return strstr($fqn, $path);

--- a/src/Lib/Route/RouteScanner.php
+++ b/src/Lib/Route/RouteScanner.php
@@ -5,6 +5,7 @@ namespace SwaggerBake\Lib\Route;
 
 use Cake\Routing\Route\Route;
 use Cake\Routing\Router;
+use Cake\Utility\Inflector;
 use InvalidArgumentException;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\Utility\NamespaceUtility;
@@ -92,7 +93,7 @@ class RouteScanner
             $routeDecorator = new RouteDecorator($route);
             $path = 'Controller\\';
             $path .= $routeDecorator->getPrefix() ? $routeDecorator->getPrefix() . '\\' : '';
-            $path .= ucfirst($routeDecorator->getController()) . 'Controller';
+            $path .= Inflector::camelize($routeDecorator->getController()) . 'Controller';
 
             $results = array_filter($classes, function ($fqn) use ($path) {
                 return strstr($fqn, $path);

--- a/tests/TestCase/Lib/Route/PrefixRouteTest.php
+++ b/tests/TestCase/Lib/Route/PrefixRouteTest.php
@@ -78,4 +78,18 @@ class PrefixRouteTest extends TestCase
         $this->assertTrue($paths->contains('/admin/departments'));
         $this->assertTrue($paths->contains('/departments'));
     }
+
+    public function test_controller_name_lowercase(): void
+    {
+        $this->router::scope('/', function (RouteBuilder $builder) {
+            $builder->get('/non-standard', ['controller' => 'operations', 'action' => 'index']);
+        });
+        $scanner = new RouteScanner($this->router, new Configuration($this->config, SWAGGER_BAKE_TEST_APP));
+        $routes = $scanner->getRoutes();
+        $this->assertArrayHasKey('operations:index', $routes);
+        $this->assertNotEmpty(
+            $routes['operations:index']->getControllerFqn(),
+            'Controller fqn has not been set for lowercase controller name'
+        );
+    }
 }

--- a/tests/TestCase/Lib/Route/PrefixRouteTest.php
+++ b/tests/TestCase/Lib/Route/PrefixRouteTest.php
@@ -83,13 +83,19 @@ class PrefixRouteTest extends TestCase
     {
         $this->router::scope('/', function (RouteBuilder $builder) {
             $builder->get('/non-standard', ['controller' => 'operations', 'action' => 'index']);
+            $builder->get('/non-standard', ['controller' => 'operation_path', 'action' => 'index']);
         });
         $scanner = new RouteScanner($this->router, new Configuration($this->config, SWAGGER_BAKE_TEST_APP));
         $routes = $scanner->getRoutes();
         $this->assertArrayHasKey('operations:index', $routes);
+        $this->assertArrayHasKey('operation_path:index', $routes);
         $this->assertNotEmpty(
             $routes['operations:index']->getControllerFqn(),
             'Controller fqn has not been set for lowercase controller name'
+        );
+        $this->assertNotEmpty(
+            $routes['operation_path:index']->getControllerFqn(),
+            'Controller fqn has not been set for snake case controller name'
         );
     }
 }


### PR DESCRIPTION
When `loadRoutes()` is invoked, it scans all routes and manually builds namespace to later find it in the class-map.
Not sure how it worked before, but `$routeDecorator->getController()` will return lowercase name of the controller (cake 4.4) thus route is not found and no routes are generated.
I can't use the latest version yet as I'm restricted to PHP 7.4 at the moment. On the other hand, I prefer to have no documentation than maintaining the YML file myself :) 

All tests are passing (not on WIndows though, DS is hardcoded to `/` so some assertions fail),
Code sniffer is complaining about EOL characters on my machine (gotta love WIndows) but I doubt that will be a problem (easily fixed).