### PR TITLE
Support array list from yaml

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -15,22 +15,22 @@ instead.
 
 | Attribute                                           | Usage                                               | Description                                                                                                                 | 
 |-----------------------------------------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| [OpenApiDto](#OpenApiDto)                           | Controller Action                                   | Builds OpenAPI query params and request bodies from Data Transfer Objects                                                   |
-| [OpenApiForm](#OpenApiForm)                         | Controller Action                                   | Builds OpenAPI for application/x-www-form-urlencoded request bodies                                                         |
-| [OpenApiHeader](#OpenApiHeader)                     | Controller Action                                   | Create OpenAPI header parameters                                                                                            |
-| [OpenApiOperation](#OpenApiOperation)               | Controller Action                                   | Modifies OpenAPI operation                                                                                                  |
-| [OpenApiPaginator](#OpenApiPaginator)               | Controller Action                                   | Create OpenAPI query params from CakePHP Paginator Component                                                                |
-| [OpenApiPath](#OpenApiPath)                         | Controller                                          | Modifies OpenAPI paths                                                                                                      |
-| [OpenApiPathParam](#OpenApiPathParam)               | Controller Action                                   | Modify an existing OpenAPI path parameter                                                                                   |
-| [OpenApiQueryParam](#OpenApiQueryParam)             | Controller Action                                   | Builds OpenAPI query param                                                                                                  |
-| [OpenApiRequestBody](#OpenApiRequestBody)           | Controller Action                                   | Modify OpenAPI request body                                                                                                 |
-| [OpenApiResponse](#OpenApiResponse)                 | Controller Action                                   | Modify OpenAPI response                                                                                                     |
-| [OpenApiSchema](#OpenApiSchema)                     | Entity, OpenApiDto class, or OpenApiResponse schema | Modifies OpenAPI schema                                                                                                     |
-| [OpenApiSchemaProperty](#OpenApiSchemaProperty)     | Entity, OpenApiDto class, or OpenApiResponse schema | Modifies an OpenAPI schema property or defines OpenApiResponse schema                                                       |
-| [OpenApiSearch](#OpenApiSearch)                     | Controller Action                                   | Create OpenAPI query params from CakePHP Search plugin                                                                      |
-| [OpenApiSecurity](#OpenApiSecurity)                 | Controller Action                                   | Create/modify OpenAPI security                                                                                              |
-| [~~OpenApiDtoQuery~~](#OpenApiDtoQuery)             | DTO class property                                  | Builds OpenAPI query param from Data Transfer Objects (deprecated, use OpenApiQueryParam in v2.2.5+)                        |
-| [~~OpenApiDtoRequestBody~~](#OpenApiDtoRequestBody) | DTO class property                                  | Builds OpenAPI request body property from Data Transfer Objects (deprecated, use OpenApiSchemaProperty in v2.2.5+)          |
+| [OpenApiDto](#openapidto)                           | Controller Action                                   | Builds OpenAPI query params and request bodies from Data Transfer Objects                                                   |
+| [OpenApiForm](#openapiform)                         | Controller Action                                   | Builds OpenAPI for application/x-www-form-urlencoded request bodies                                                         |
+| [OpenApiHeader](#openapiheader)                     | Controller Action                                   | Create OpenAPI header parameters                                                                                            |
+| [OpenApiOperation](#openapioperation)               | Controller Action                                   | Modifies OpenAPI operation                                                                                                  |
+| [OpenApiPaginator](#openapipaginator)               | Controller Action                                   | Create OpenAPI query params from CakePHP Paginator Component                                                                |
+| [OpenApiPath](#openapipath)                         | Controller                                          | Modifies OpenAPI paths                                                                                                      |
+| [OpenApiPathParam](#openapipathparam)               | Controller Action                                   | Modify an existing OpenAPI path parameter                                                                                   |
+| [OpenApiQueryParam](#openapiqueryparam)             | Controller Action                                   | Builds OpenAPI query param                                                                                                  |
+| [OpenApiRequestBody](#openapirequestbody)           | Controller Action                                   | Modify OpenAPI request body                                                                                                 |
+| [OpenApiResponse](#openapiresponse)                 | Controller Action                                   | Modify OpenAPI response                                                                                                     |
+| [OpenApiSchema](#openapischema)                     | Entity, OpenApiDto class, or OpenApiResponse schema | Modifies OpenAPI schema                                                                                                     |
+| [OpenApiSchemaProperty](#openapischemaproperty)     | Entity, OpenApiDto class, or OpenApiResponse schema | Modifies an OpenAPI schema property or defines OpenApiResponse schema                                                       |
+| [OpenApiSearch](#openapisearch)                     | Controller Action                                   | Create OpenAPI query params from CakePHP Search plugin                                                                      |
+| [OpenApiSecurity](#openapisecurity)                 | Controller Action                                   | Create/modify OpenAPI security                                                                                              |
+| [~~OpenApiDtoQuery~~](#openapidtoquery)             | DTO class property                                  | Builds OpenAPI query param from Data Transfer Objects (deprecated, use OpenApiQueryParam in v2.2.5+)                        |
+| [~~OpenApiDtoRequestBody~~](#openapidtorequestbody) | DTO class property                                  | Builds OpenAPI request body property from Data Transfer Objects (deprecated, use OpenApiSchemaProperty in v2.2.5+)          |
 
 ### OpenApiDto
 
@@ -38,13 +38,13 @@ Method level attribute for building query parameters or request bodies from a Da
 
 For versions v2.2.5 or higher use:
 
-Your DTO will need to use the [OpenApiQueryParam](#OpenApiQueryParam) or [OpenApiSchemaProperty](#OpenApiSchemaProperty) 
+Your DTO will need to use the [OpenApiQueryParam](#openapiqueryparam) or [OpenApiSchemaProperty](#openapischemaproperty) 
 on its properties depending on the request type. The OpenApiDtoQuery and OpenApiDtoRequestBody attributes are marked 
 deprecated and will be removed in v3.0.0 which will be released for CakePHP 5.
 
 For versions v2.2.4 or lower:
 
-Your DTO will need to use the [OpenApiDtoQuery](#OpenApiDtoQuery) or [OpenApiDtoRequestBody](#OpenApiDtoRequestBody) on 
+Your DTO will need to use the [OpenApiDtoQuery](#openapidtoquery) or [OpenApiDtoRequestBody](#openapidtorequestbody) on 
 its properties depending on the request type.
 
 | Property   | Type / Default | OA Spec | Description                     | 
@@ -409,16 +409,16 @@ order of operations is used to build the response:
 3. `associations`
 4. The schema inferred from CakePHP conventions.
 
-| Property                      | Type / Default    | OA Spec | Description                                                                                                                                                           |
-|-------------------------------|-------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| schemaType                    | string `"object"` | Y       | The schema response type, generally `"object"` or `"array"`                                                                                                           |
-| statusCode                    | string `"200"`    | Y       | The HTTP response code                                                                                                                                                |
-| ref                           | ?string `null`    | Y       | The OpenAPI schema (e.g. `"#/components/schemas/ModelName"`                                                                                                           |
-| [schema](#Schema)             | ?string `null`    | Y       | An FQN describing a custom response schema. The class must have either one or more `#[OpenApiSchemaProperty]` attribute, implement `CustomSchemaInterface` or both.   |
-| description                   | ?string `null`    | Y       | Description of the response                                                                                                                                           |
-| mimeTypes                     | ?array `null`     | Y       | An array of mime types the response can, if null settings from swagger_bake config are used.                                                                          |
-| [associations](#Associations) | ?array `null`     | N       | Adds associated tables to the response sample schema, see examples below.                                                                                             |
-| schemaFormat                  | ?string `null`    | Y       | The schema format, generally only used for schemaType of string.                                                                                                      |
+| Property                      | Type / Default    | OA Spec | Description                                                                                                                                                         |
+|-------------------------------|-------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| schemaType                    | string `"object"` | Y       | The schema response type, generally `"object"`, `"array"`, or `""`                                                                                                  |
+| statusCode                    | string `"200"`    | Y       | The HTTP response code                                                                                                                                              |
+| ref                           | ?string `null`    | Y       | The OpenAPI schema (e.g. `"#/components/schemas/ModelName"`                                                                                                         |
+| [schema](#Schema)             | ?string `null`    | Y       | An FQN describing a custom response schema. The class must have either one or more `#[OpenApiSchemaProperty]` attribute, implement `CustomSchemaInterface` or both. |
+| description                   | ?string `null`    | Y       | Description of the response                                                                                                                                         |
+| mimeTypes                     | ?array `null`     | Y       | An array of mime types the response can, if null settings from swagger_bake config are used.                                                                        |
+| [associations](#Associations) | ?array `null`     | N       | Adds associated tables to the response sample schema, see examples below.                                                                                           |
+| schemaFormat                  | ?string `null`    | Y       | The schema format, generally only used for schemaType of string.                                                                                                    |
 
 Defining a multiple mimeTypes and 400-409 status code range and an expected 200 response:
 

--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -42,6 +42,8 @@ class Schema implements JsonSerializable, SchemaInterface
      * @param int $visibility See OpenApiSchema class constants
      * @param string|null $refPath OpenAPI $ref such as #/components/schema/MyModel
      * @param bool $isCustomSchema Denotes if this schema was added via a DTO or Response attribute.
+     * @param mixed|null $example Sets an example, note this is marked as deprecated in the OpenAPI spec and its
+     *  use is discouraged. This will be replaced by examples spec in a future release.
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -58,6 +60,7 @@ class Schema implements JsonSerializable, SchemaInterface
         private int $visibility = OpenApiSchema::VISIBLE_DEFAULT,
         private ?string $refPath = null,
         private bool $isCustomSchema = false,
+        private mixed $example = null
     ) {
     }
 
@@ -88,7 +91,7 @@ class Schema implements JsonSerializable, SchemaInterface
         );
 
         // remove null properties only
-        $vars = ArrayUtility::removeNullValues($vars, ['description']);
+        $vars = ArrayUtility::removeNullValues($vars, ['description', 'example']);
 
         return $vars;
     }
@@ -432,6 +435,29 @@ class Schema implements JsonSerializable, SchemaInterface
     public function setIsCustomSchema(bool $isCustomSchema)
     {
         $this->isCustomSchema = $isCustomSchema;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated This will be removed from the OpenAPI spec and its use is currently discouraged
+     * @todo implement examples
+     * @return mixed|null
+     */
+    public function getExample(): mixed
+    {
+        return $this->example;
+    }
+
+    /**
+     * @deprecated This will be removed from the OpenAPI spec and its use is currently discouraged
+     * @todo implement examples
+     * @param mixed|null $example
+     * @return $this
+     */
+    public function setExample(mixed $example)
+    {
+        $this->example = $example;
 
         return $this;
     }

--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -452,7 +452,7 @@ class Schema implements JsonSerializable, SchemaInterface
     /**
      * @deprecated This will be removed from the OpenAPI spec and its use is currently discouraged
      * @todo implement examples
-     * @param mixed|null $example
+     * @param mixed|null $example An optional example of the schema
      * @return $this
      */
     public function setExample(mixed $example)

--- a/src/Lib/Schema/SchemaFromYamlFactory.php
+++ b/src/Lib/Schema/SchemaFromYamlFactory.php
@@ -25,13 +25,14 @@ class SchemaFromYamlFactory
         $schema = (new Schema())
             ->setName($name)
             ->setTitle($yml['title'] ?? null)
-            ->setType($yml['type'] ?? null)
+            ->setType($yml['type'] ?? '')
             ->setDescription($yml['description'] ?? null)
             ->setItems($yml['items'] ?? [])
             ->setAllOf($yml['allOf'] ?? [])
             ->setAnyOf($yml['anyOf'] ?? [])
             ->setOneOf($yml['oneOf'] ?? [])
-            ->setNot($yml['oneOf'] ?? []);
+            ->setNot($yml['oneOf'] ?? [])
+            ->setExample($yml['example'] ?? null);
 
         if (isset($yml['xml'])) {
             $schema->setXml(

--- a/src/Lib/Utility/OpenApiDataType.php
+++ b/src/Lib/Utility/OpenApiDataType.php
@@ -16,6 +16,7 @@ class OpenApiDataType
     public const NUMBER = 'number';
     public const OBJECT = 'object';
     public const STRING = 'string';
+    public const EMPTY = '';
 
     /**
      * @var string[]
@@ -27,5 +28,6 @@ class OpenApiDataType
         self::NUMBER,
         self::OBJECT,
         self::STRING,
+        self::EMPTY,
     ];
 }

--- a/tests/TestCase/Lib/Schema/SchemaFromYamlFactoryTest.php
+++ b/tests/TestCase/Lib/Schema/SchemaFromYamlFactoryTest.php
@@ -11,7 +11,7 @@ class SchemaFromYamlFactoryTest extends TestCase
 {
     public function test_nested_objects(): void
     {
-        $yaml = Yaml::parseFile(CONFIG . 'openapi-with-nested-objects.yml');
+        $yaml = Yaml::parseFile(CONFIG . 'test-cases.yml');
         $schema = (new SchemaFromYamlFactory())->create(
             'Place',
             $yaml['components']['schemas']['Place']
@@ -24,5 +24,17 @@ class SchemaFromYamlFactoryTest extends TestCase
         /** @var Schema $relationships */
         $relationships = $schema->getProperties()['relationships'];
         $this->assertTrue(isset($relationships->getProperties()['description']));
+    }
+
+    public function test_array_list(): void
+    {
+        $yaml = Yaml::parseFile(CONFIG . 'test-cases.yml');
+        $schema = (new SchemaFromYamlFactory())->create(
+            'Year',
+            $yaml['components']['schemas']['Year']
+        );
+
+        $this->assertEquals(['type' => 'integer'], $schema->getItems());
+        $this->assertEquals([2022, 2021, 2020], $schema->getExample());
     }
 }

--- a/tests/test_app/config/test-cases.yml
+++ b/tests/test_app/config/test-cases.yml
@@ -6,6 +6,13 @@ info:
     name: MIT
 components:
   schemas:
+    # Test simple array list
+    Year:
+      type: array
+      items:
+        type: integer
+      example: [ 2022, 2021, 2020 ]
+    # Test nested objects
     Place:
       description: 'Country object'
       type: object


### PR DESCRIPTION
Adds support for the following YAML:

```yaml
    Year:
      type: array
      items:
        type: integer
      example: [2022, 2021, 2020]
```

So it can be referenced like this:

```php
#[OpenApiResponse(schemaType: '', ref: '#/components/schemas/Year')]
```