### PR TITLE
Add ReturnTypeWillChange attribute

### DIFF
--- a/src/Lib/OpenApi/PathSecurity.php
+++ b/src/Lib/OpenApi/PathSecurity.php
@@ -37,6 +37,7 @@ class PathSecurity implements JsonSerializable
     /**
      * @return array|array[]|mixed
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();


### PR DESCRIPTION
Adds the `#[\ReturnTypeWillChange]` attribute to the jsonSerialize method in `PathSecurity.php`, fixing yet another PHP8.1 deprecation warning.

Steps I've taken to ensure the fix is good:
- Ran unit tests - all passing
- Set up a test project locally and ran `./bin/cake swagger bake` with this branch - no errors or warnings
- Viewed the generated Swagger docs and confirmed the deprecation error is gone

However, when I ran `composer analyze` there are numerous additional jsonSerialize problems in the PHPStan library itself, ironically. This results in a phpstan error.