### PR TITLE
Move openapi build logic out of constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ to SwaggerUI (or Redoc) in your web browser.
 
 ```php
 $swagger = (new \SwaggerBake\Lib\SwaggerFactory())->create();
+$swagger->build(); # builds openapi, this returns self so `$swagger->build()->getArray()` is possible.
 $swagger->getArray(); # returns swagger array
 $swagger->toString(); # returns swagger json
 $swagger->writeFile('/full/path/to/your/swagger.json'); # writes swagger.json

--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ to SwaggerUI (or Redoc) in your web browser.
 - You can also generate OpenAPI programmatically: 
 
 ```php
-$swagger = (new \SwaggerBake\Lib\SwaggerFactory())->create();
-$swagger->build(); # builds openapi, this returns self so `$swagger->build()->getArray()` is possible.
+$swagger = (new \SwaggerBake\Lib\SwaggerFactory())->create()->build();
 $swagger->getArray(); # returns swagger array
 $swagger->toString(); # returns swagger json
 $swagger->writeFile('/full/path/to/your/swagger.json'); # writes swagger.json

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "friendsofcake/search": "^6.0",
         "cakephp/authentication": "^2.0",
         "cakephp/cakephp-codesniffer": "^4.2",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^1.8.5",
         "phpmd/phpmd": "^2.10",
         "cakephp/bake": "^2.1"
     },

--- a/src/Lib/Service/OpenApiBakerService.php
+++ b/src/Lib/Service/OpenApiBakerService.php
@@ -16,10 +16,11 @@ class OpenApiBakerService
      * @param string $filePath The file path to write the openapi json to
      * @return string
      * @throws \SwaggerBake\Lib\Exception\SwaggerBakeRunTimeException
+     * @throws \ReflectionException
      */
     public function bake(Swagger $swagger, string $filePath): string
     {
-        $swagger->writeFile($filePath);
+        $swagger->build()->writeFile($filePath);
         foreach ($swagger->getOperationsWithNoHttp20x() as $operation) {
             $this->warnings[] = 'Operation ' . $operation->getOperationId() . ' does not have a HTTP 20x response';
         }

--- a/src/Lib/Service/OpenApiControllerService.php
+++ b/src/Lib/Service/OpenApiControllerService.php
@@ -30,12 +30,13 @@ class OpenApiControllerService
      * Rebuilds OpenAPI if hot reload is enabled and logs warnings if debug is enabled
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function build(): void
     {
         if ($this->config->isHotReload()) {
             $output = $this->config->getJson();
-            $this->swagger->writeFile($output);
+            $this->swagger->build()->writeFile($output);
         }
     }
 

--- a/tests/TestCase/Lib/Attribute/OpenApiDtoTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiDtoTest.php
@@ -87,7 +87,7 @@ class OpenApiDtoTest extends TestCase
     public function test_openapi_dto_query(): void
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
 
@@ -101,7 +101,7 @@ class OpenApiDtoTest extends TestCase
     public function test_openapi_dto_post(): void
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
 

--- a/tests/TestCase/Lib/Attribute/OpenApiEntityAttributeTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiEntityAttributeTest.php
@@ -55,7 +55,7 @@ class OpenApiEntityAttributeTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         $arr = json_decode($swagger->toString(), true);
 

--- a/tests/TestCase/Lib/Attribute/OpenApiFormTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiFormTest.php
@@ -64,7 +64,7 @@ class OpenApiFormTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $operation = $arr['paths']['/employees/custom-post']['post'];

--- a/tests/TestCase/Lib/Attribute/OpenApiHeaderTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiHeaderTest.php
@@ -38,7 +38,7 @@ class OpenApiHeaderTest extends TestCase
         $this->__setUp();
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $this->assertArrayHasKey('/employees/custom-get', $arr['paths']);

--- a/tests/TestCase/Lib/Attribute/OpenApiOperationTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiOperationTest.php
@@ -85,37 +85,37 @@ class OpenApiOperationTest extends TestCase
 
         $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $configuration);
-        $this->swagger = new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration);
+        $this->swagger = (new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration))->build();
     }
 
     public function test_descriptions(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $this->assertEquals('summary...', $arr['paths']['/operations/descriptions']['get']['summary']);
         $this->assertEquals('desc...', $arr['paths']['/operations/descriptions']['get']['description']);
     }
 
     public function test_is_visible(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $this->assertArrayNotHasKey('/operations/is-visible', $arr['paths']);
     }
 
     public function test_operation_tags_names_should_take_precedence(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $this->assertCount(4, $arr['paths']['/operations/tag-names']['get']['tags']);
     }
 
     public function test_is_deprecated(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $this->assertTrue($arr['paths']['/operations/deprecated']['get']['deprecated']);
     }
 
     public function test_external_docs(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $externalDocs = $arr['paths']['/operations/external-docs']['get']['externalDocs'];
         $this->assertEquals('http://localhost', $externalDocs['url']);
         $this->assertEquals('desc...', $externalDocs['description']);
@@ -123,7 +123,7 @@ class OpenApiOperationTest extends TestCase
 
     public function test_path_tags_should_take_precedence(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $this->assertCount(2, $arr['paths']['/operations/deprecated']['get']['tags']);
         $this->assertCount(2, $arr['paths']['/operations/external-docs']['get']['tags']);
     }

--- a/tests/TestCase/Lib/Attribute/OpenApiPaginatorTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiPaginatorTest.php
@@ -55,7 +55,7 @@ class OpenApiPaginatorTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $this->assertArrayHasKey('/departments', $arr['paths']);

--- a/tests/TestCase/Lib/Attribute/OpenApiPathParamTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiPathParamTest.php
@@ -50,7 +50,7 @@ class OpenApiPathParamTest extends TestCase
 
         $cakeRoute = new RouteScanner($router, $config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $config), $config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $params = $arr['paths']['/operation-path/path-parameter/{id}']['get']['parameters'];

--- a/tests/TestCase/Lib/Attribute/OpenApiPathTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiPathTest.php
@@ -57,7 +57,7 @@ class OpenApiPathTest extends TestCase
 
         $cakeRoute = new RouteScanner($this->router, $config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $config), $config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build();
 
         $arr = json_decode($swagger->toString(), true);
         $employees = $arr['paths']['/employees'];
@@ -72,7 +72,7 @@ class OpenApiPathTest extends TestCase
 
         $cakeRoute = new RouteScanner($this->router, $config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $config), $config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build();
 
         $arr = json_decode($swagger->toString(), true);
 

--- a/tests/TestCase/Lib/Attribute/OpenApiQueryParamTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiQueryParamTest.php
@@ -38,7 +38,7 @@ class OpenApiQueryParamTest extends TestCase
         $this->__setUp();
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $this->assertArrayHasKey('/departments', $arr['paths']);

--- a/tests/TestCase/Lib/Attribute/OpenApiRequestBodyTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiRequestBodyTest.php
@@ -83,7 +83,7 @@ class OpenApiRequestBodyTest extends TestCase
     {
         $routeScanner = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($routeScanner, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($routeScanner, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $operation = $arr['paths']['/employees/custom-post']['post'];
@@ -98,7 +98,7 @@ class OpenApiRequestBodyTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $operation = $arr['paths']['/request-body/text-plain']['post'];
@@ -110,7 +110,7 @@ class OpenApiRequestBodyTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $operation = $arr['paths']['/request-body/multiple-mime-types']['post'];
@@ -122,7 +122,7 @@ class OpenApiRequestBodyTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $operation = $arr['paths']['/request-body/use-config-defaults']['post'];

--- a/tests/TestCase/Lib/Attribute/OpenApiResponseTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiResponseTest.php
@@ -78,12 +78,12 @@ class OpenApiResponseTest extends TestCase
         ], SWAGGER_BAKE_TEST_APP);
 
         $cakeRoute = new RouteScanner($router, $config);
-        $this->swagger = new Swagger(new ModelScanner($cakeRoute, $config), $config);
+        $this->swagger = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build();
     }
 
     public function test_openapi_response_ref(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
 
         $operation = $arr['paths']['/employees/custom-response-ref']['get'];
 
@@ -99,7 +99,7 @@ class OpenApiResponseTest extends TestCase
 
     public function test_openapi_response_schema(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $operation = $arr['paths']['/employees/custom-response-schema']['get'];
         $schema = $operation['responses'][200]['content']['application/json']['schema'];
         $this->assertEquals('Custom Title', $schema['title']);
@@ -109,7 +109,7 @@ class OpenApiResponseTest extends TestCase
 
     public function test_openapi_response_schema_public(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $this->assertArrayHasKey('CustomResponseSchemaPublic', $arr['components']['schemas']);
         $properties = $arr['components']['schemas']['CustomResponseSchemaPublic']['properties'];
         $this->assertArrayHasKey('name', $properties);
@@ -122,7 +122,7 @@ class OpenApiResponseTest extends TestCase
 
     public function test_openapi_response_schema_public_array(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $operation = $arr['paths']['/employees/custom-response-schema-public-array']['get'];
         $ref = $operation['responses'][200]['content']['application/json']['schema']['items']['$ref'];
         $this->assertEquals('#/components/schemas/CustomResponseSchemaPublic', $ref);

--- a/tests/TestCase/Lib/Attribute/OpenApiSchemaTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiSchemaTest.php
@@ -60,7 +60,7 @@ class OpenApiSchemaTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         $arr = json_decode($swagger->toString(), true);
 
@@ -74,7 +74,7 @@ class OpenApiSchemaTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         $arr = json_decode($swagger->toString(), true);
 
@@ -89,7 +89,7 @@ class OpenApiSchemaTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         $arr = json_decode($swagger->toString(), true);
 
@@ -101,7 +101,7 @@ class OpenApiSchemaTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         $arr = json_decode($swagger->toString(), true);
 

--- a/tests/TestCase/Lib/Attribute/OpenApiSecurityTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiSecurityTest.php
@@ -62,7 +62,7 @@ class OpenApiSecurityTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $this->assertArrayHasKey('/employees/custom-get', $arr['paths']);

--- a/tests/TestCase/Lib/Extension/CakeSearch/ExtensionTest.php
+++ b/tests/TestCase/Lib/Extension/CakeSearch/ExtensionTest.php
@@ -82,7 +82,7 @@ class ExtensionTest extends TestCase
         $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
 
         $cakeRoute = new RouteScanner($this->router, $configuration);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration))->build();
 
         $arr = json_decode($swagger->toString(), true);
 

--- a/tests/TestCase/Lib/MediaType/GenericTest.php
+++ b/tests/TestCase/Lib/MediaType/GenericTest.php
@@ -43,7 +43,7 @@ class GenericTest extends TestCase
     public function test_collection(): void
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $schema = (new Generic($swagger))->buildSchema('#/components/schemas/thing', 'array');
         $this->assertEquals(
             '#/x-swagger-bake/components/schemas/Generic-Collection',
@@ -55,7 +55,7 @@ class GenericTest extends TestCase
     public function test_collection_with_associations(): void
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         $schema = (new Schema())
             ->setAllOf(['$ref' => $parentRef = '#/components/schemas/City'])

--- a/tests/TestCase/Lib/MediaType/HalJsonIntegrationTest.php
+++ b/tests/TestCase/Lib/MediaType/HalJsonIntegrationTest.php
@@ -9,6 +9,7 @@ use Cake\TestSuite\TestCase;
 use SwaggerBake\Lib\Configuration;
 use SwaggerBake\Lib\MediaType\HalJson;
 use SwaggerBake\Lib\Model\ModelScanner;
+use SwaggerBake\Lib\OpenApi\Schema;
 use SwaggerBake\Lib\Route\RouteScanner;
 use SwaggerBake\Lib\Swagger;
 
@@ -57,11 +58,12 @@ class HalJsonIntegrationTest extends TestCase
     public function test_collection(): void
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         /** @var \SwaggerBake\Lib\OpenApi\Path $path */
         $path = $swagger->getArray()['paths']['/employees'];
         $content = $path->getOperations()['get']->getResponses()['200']->getContent()['application/hal+json'];
+        /** @var Schema $schema */
         $schema = $content->getSchema();
 
         $this->assertEquals(HalJson::HAL_COLLECTION, $schema->getAllOf()[0]['$ref']);
@@ -78,11 +80,12 @@ class HalJsonIntegrationTest extends TestCase
     public function test_item(): void
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         /** @var \SwaggerBake\Lib\OpenApi\Path $path */
         $path = $swagger->getArray()['paths']['/employees/{id}'];
         $content = $path->getOperations()['get']->getResponses()['200']->getContent()['application/hal+json'];
+        /** @var Schema $schema */
         $schema = $content->getSchema();
 
         $this->assertEquals(

--- a/tests/TestCase/Lib/MediaType/JsonLdIntegrationTest.php
+++ b/tests/TestCase/Lib/MediaType/JsonLdIntegrationTest.php
@@ -58,7 +58,7 @@ class JsonLdIntegrationTest extends TestCase
     public function test_collection(): void
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         /** @var \SwaggerBake\Lib\OpenApi\Path $path */
         $path = $swagger->getArray()['paths']['/employees'];
@@ -79,7 +79,7 @@ class JsonLdIntegrationTest extends TestCase
     public function test_item(): void
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         /** @var \SwaggerBake\Lib\OpenApi\Path $path */
         $path = $swagger->getArray()['paths']['/employees/{id}'];

--- a/tests/TestCase/Lib/MediaType/MediaTypeTraitTest.php
+++ b/tests/TestCase/Lib/MediaType/MediaTypeTraitTest.php
@@ -32,7 +32,7 @@ class MediaTypeTraitTest extends TestCase
         ], SWAGGER_BAKE_TEST_APP);
 
         $cakeRoute = new RouteScanner(new Router(), $config);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $config), $config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build();
 
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/TestCase/Lib/Operation/OperationRequestBodyTest.php
+++ b/tests/TestCase/Lib/Operation/OperationRequestBodyTest.php
@@ -46,7 +46,7 @@ class OperationRequestBodyTest extends TestCase
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $config);
         $cakeModels = new ModelScanner($cakeRoute, $config);
-        $swagger = new Swagger($cakeModels, $config);
+        $swagger = (new Swagger($cakeModels, $config))->build();
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];
@@ -102,7 +102,7 @@ class OperationRequestBodyTest extends TestCase
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $config);
         $cakeModels = new ModelScanner($cakeRoute, $config);
-        $swagger = new Swagger($cakeModels, $config);
+        $swagger = (new Swagger($cakeModels, $config))->build();
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];
@@ -166,7 +166,7 @@ class OperationRequestBodyTest extends TestCase
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $config);
         $cakeModels = new ModelScanner($cakeRoute, $config);
-        $swagger = new Swagger($cakeModels, $config);
+        $swagger = (new Swagger($cakeModels, $config))->build();
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];
@@ -237,7 +237,7 @@ class OperationRequestBodyTest extends TestCase
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $config);
         $cakeModels = new ModelScanner($cakeRoute, $config);
-        $swagger = new Swagger($cakeModels, $config);
+        $swagger = (new Swagger($cakeModels, $config))->build();
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];
@@ -311,7 +311,7 @@ class OperationRequestBodyTest extends TestCase
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $config);
         $cakeModels = new ModelScanner($cakeRoute, $config);
-        $swagger = new Swagger($cakeModels, $config);
+        $swagger = (new Swagger($cakeModels, $config))->build();
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];

--- a/tests/TestCase/Lib/Operation/OperationRequestBodyYamlTest.php
+++ b/tests/TestCase/Lib/Operation/OperationRequestBodyYamlTest.php
@@ -62,7 +62,7 @@ class OperationRequestBodyYamlTest extends TestCase
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $config);
         $cakeModels = new ModelScanner($cakeRoute, $config);
-        $swagger = new Swagger($cakeModels, $config);
+        $swagger = (new Swagger($cakeModels, $config))->build();
 
         $routes = $cakeRoute->getRoutes();
         $route = $routes['employees:add'];

--- a/tests/TestCase/Lib/Operation/OperationResponseTest.php
+++ b/tests/TestCase/Lib/Operation/OperationResponseTest.php
@@ -129,7 +129,7 @@ class OperationResponseTest extends TestCase
             );
 
         $operationResponse = new OperationResponse(
-            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create()->build(),
             $this->config,
             new Operation('employees:add', 'post'),
             $route,
@@ -153,7 +153,7 @@ class OperationResponseTest extends TestCase
         $schema = (new Schema())->setName('Employee')->setType('object');
 
         $operationResponse = new OperationResponse(
-            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create()->build(),
             $this->config,
             new Operation('employees:add', 'post'),
             $route,
@@ -186,7 +186,7 @@ class OperationResponseTest extends TestCase
             );
 
         $operationResponse = new OperationResponse(
-            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create()->build(),
             $this->config,
             new Operation('employees:add', 'post'),
             $route,
@@ -219,7 +219,7 @@ class OperationResponseTest extends TestCase
             );
 
         $operationResponse = new OperationResponse(
-            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create()->build(),
             $this->config,
             new Operation('employees:delete', 'delete'),
             $route,
@@ -331,7 +331,9 @@ class OperationResponseTest extends TestCase
             'associations' => ['whiteList' => ['DepartmentEmployees']]
         ]);
 
-        $swagger = (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create();
+        $swagger = (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))
+            ->create()
+            ->build();
 
         $operationResponse = new OperationResponse(
             $swagger,

--- a/tests/TestCase/Lib/Operation/OperationResponseYamlTest.php
+++ b/tests/TestCase/Lib/Operation/OperationResponseYamlTest.php
@@ -71,7 +71,9 @@ class OperationResponseYamlTest extends TestCase
     public function test_yaml_schema_overwriting_cakephp_model_schema(): void
     {
         $route = $this->routes['employees:view'];
-        $swagger = (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create();
+        $swagger = (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))
+            ->create()
+            ->build();
 
         $operationResponse = new OperationResponse(
             $swagger,

--- a/tests/TestCase/Lib/Route/PrefixRouteTest.php
+++ b/tests/TestCase/Lib/Route/PrefixRouteTest.php
@@ -67,7 +67,7 @@ class PrefixRouteTest extends TestCase
     {
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $config);
-        $openApi = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->getArray();
+        $openApi = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build()->getArray();
         $paths = new Collection(array_keys($openApi['paths']));
         $this->assertTrue($paths->contains('/admin/departments'));
         $this->assertTrue($paths->contains('/departments'));

--- a/tests/TestCase/Lib/Service/OpenApiBakerServiceTest.php
+++ b/tests/TestCase/Lib/Service/OpenApiBakerServiceTest.php
@@ -11,10 +11,16 @@ class OpenApiBakerServiceTest extends TestCase
 {
     public function test_warnings(): void
     {
-        $mock = $this->createPartialMock(Swagger::class, ['writeFile', 'getOperationsWithNoHttp20x']);
-        $mock
-            ->expects($this->once())
-            ->method('writeFile');
+        $mock = $this->createPartialMock(Swagger::class, [
+            'build',
+            'writeFile',
+            'getOperationsWithNoHttp20x'
+        ]);
+
+
+        $mock->expects($this->once())->method('build')->willReturn($mock);
+        $mock->expects($this->once())->method('writeFile');
+
         $mock
             ->expects($this->once())
             ->method('getOperationsWithNoHttp20x')

--- a/tests/TestCase/Lib/SwaggerOperationTest.php
+++ b/tests/TestCase/Lib/SwaggerOperationTest.php
@@ -73,12 +73,12 @@ class SwaggerOperationTest extends TestCase
 
         $configuration = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $configuration);
-        $this->swagger = new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration);
+        $this->swagger = (new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration))->build();
     }
 
     public function test_crud_operations_exist(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
 
         $this->assertArrayHasKey('get', $arr['paths']['/employees']);
         $this->assertArrayHasKey('post', $arr['paths']['/employees']);
@@ -90,7 +90,7 @@ class SwaggerOperationTest extends TestCase
 
     public function test_default_response_schema_on_index_method(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
 
         $employee = $arr['paths']['/employees']['get'];
 
@@ -102,7 +102,7 @@ class SwaggerOperationTest extends TestCase
 
     public function test_default_request_schema_on_add_method(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
 
         $employee = $arr['paths']['/employees']['post'];
         $schema =  $employee['requestBody']['content']['application/x-www-form-urlencoded']['schema'];
@@ -114,7 +114,7 @@ class SwaggerOperationTest extends TestCase
 
     public function test_default_response_schema_on_add_method(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
 
         $employee = $arr['paths']['/employees']['post'];
         $schema = $employee['responses'][200]['content']['application/json']['schema'];
@@ -124,7 +124,7 @@ class SwaggerOperationTest extends TestCase
 
     public function test_default_request_body_schema_on_edit_method(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
 
         $employee = $arr['paths']['/employees/{id}']['patch'];
         $schema = $employee['requestBody']['content']['application/x-www-form-urlencoded']['schema'];
@@ -136,7 +136,7 @@ class SwaggerOperationTest extends TestCase
 
     public function test_default_response_schema_on_edit_method(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
 
         $employee = $arr['paths']['/employees/{id}']['patch'];
 
@@ -147,7 +147,7 @@ class SwaggerOperationTest extends TestCase
 
     public function test_exception_response_schema(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
 
         $responses = $arr['paths']['/employees/custom-get']['get']['responses'];
 
@@ -164,7 +164,7 @@ class SwaggerOperationTest extends TestCase
         $configuration = new Configuration($config, SWAGGER_BAKE_TEST_APP);
 
         $cakeRoute = new RouteScanner($this->router, $configuration);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration))->build();
 
         $arr = json_decode($swagger->toString(), true);
 
@@ -181,7 +181,7 @@ class SwaggerOperationTest extends TestCase
         $configuration = new Configuration($config, SWAGGER_BAKE_TEST_APP);
 
         $cakeRoute = new RouteScanner($this->router, $configuration);
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $configuration), $configuration))->build();
 
         $arr = json_decode($swagger->toString(), true);
         $securities = $arr['paths']['/departments/{id}']['get']['security'];
@@ -193,7 +193,7 @@ class SwaggerOperationTest extends TestCase
 
     public function test_path_parameter_is_defined(): void
     {
-        $arr = json_decode($this->swagger->toString(), true);
+        $arr = json_decode($this->swagger->build()->toString(), true);
         $operation = $arr['paths']['/employees/{id}']['get'];
 
         $this->assertEquals('path', $operation['parameters'][0]['in']);

--- a/tests/TestCase/Lib/SwaggerSchemaTest.php
+++ b/tests/TestCase/Lib/SwaggerSchemaTest.php
@@ -56,7 +56,7 @@ class SwaggerSchemaTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $this->assertArrayHasKey('Employee', $arr['components']['schemas']);
@@ -88,7 +88,7 @@ class SwaggerSchemaTest extends TestCase
     {
         $cakeRoute = new RouteScanner($this->router, $this->config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $this->config), $this->config))->build();
 
         $arr = json_decode($swagger->toString(), true);
 

--- a/tests/TestCase/Lib/SwaggerTest.php
+++ b/tests/TestCase/Lib/SwaggerTest.php
@@ -79,7 +79,7 @@ class SwaggerTest extends TestCase
     {
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $cakeRoute = new RouteScanner($this->router, $config);
-        $openApi = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->getArray();
+        $openApi = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build()->getArray();
 
         $this->assertArrayHasKey('/departments', $openApi['paths']);
         $this->assertArrayHasKey('/pets', $openApi['paths']);
@@ -94,7 +94,7 @@ class SwaggerTest extends TestCase
 
         $cakeRoute = new RouteScanner($this->router, $config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $config), $config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build();
         $arr = json_decode($swagger->toString(), true);
 
         $this->assertArrayHasKey('/departments', $arr['paths']);
@@ -109,7 +109,7 @@ class SwaggerTest extends TestCase
 
         $cakeRoute = new RouteScanner($this->router, $config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $config), $config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build();
         $jsonString = $swagger->toString();
 
         $this->assertStringNotContainsString('"\/departments"', $jsonString);
@@ -130,7 +130,7 @@ class SwaggerTest extends TestCase
 
         $cakeRoute = new RouteScanner($this->router, $config);
 
-        $swagger = new Swagger(new ModelScanner($cakeRoute, $config), $config);
+        $swagger = (new Swagger(new ModelScanner($cakeRoute, $config), $config))->build();
         $openApi = $swagger->getArray();
         /** @var Path $path */
         $path = $openApi['paths']['/employees/{id}'];
@@ -178,7 +178,7 @@ class SwaggerTest extends TestCase
     {
         $config = new Configuration($this->config, SWAGGER_BAKE_TEST_APP);
         $routeScanner = new RouteScanner($this->router, $config);
-        $swagger = new Swagger(new ModelScanner($routeScanner, $config), $config);
+        $swagger = (new Swagger(new ModelScanner($routeScanner, $config), $config))->build();
         $array = $swagger->getArray();
         $array['components'] = [];
         $swagger->setArray($array);


### PR DESCRIPTION
Resolves #454

The `build` method must now be called on Swagger to build the OpenAPI array. This resolves performance issues and removes a bad practice of executing heavy logic in constructors.

Example:

```php
$swagger = (new SwaggerFactory())->create()->build();
```