### PR TITLE
Fix bug with forward slashes in route prefixes

### DIFF
--- a/src/Lib/Route/RouteDecorator.php
+++ b/src/Lib/Route/RouteDecorator.php
@@ -128,7 +128,7 @@ class RouteDecorator
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getName(): ?string
     {
@@ -166,7 +166,7 @@ class RouteDecorator
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPlugin(): ?string
     {
@@ -185,7 +185,7 @@ class RouteDecorator
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getController(): ?string
     {
@@ -204,7 +204,7 @@ class RouteDecorator
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getAction(): ?string
     {
@@ -242,7 +242,7 @@ class RouteDecorator
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTemplate(): ?string
     {
@@ -350,7 +350,7 @@ class RouteDecorator
         $app = $this->cakeConfigure::read('App.namespace');
         $fqn = $this->plugin ? $this->plugin . '\\' : $app . '\\';
         $fqn .= 'Controller\\';
-        $fqn .= $this->prefix ? $this->prefix . '\\' : '';
+        $fqn .= $this->prefix ? str_replace('/', '\\', $this->prefix) . '\\' : '';
 
         if (class_exists($fqn . $this->controller . 'Controller')) {
             return $fqn . $this->controller . 'Controller';

--- a/tests/TestCase/Lib/Route/RouteDecoratorTest.php
+++ b/tests/TestCase/Lib/Route/RouteDecoratorTest.php
@@ -8,7 +8,10 @@ use SwaggerBake\Lib\Route\RouteDecorator;
 
 class RouteDecoratorTest extends TestCase
 {
-    public function test_construct(): void
+    /**
+     * When `__construct` is called, the route is properly decorated.
+     */
+    public function test(): void
     {
         $defaults = [
             'plugin' => null,
@@ -18,7 +21,6 @@ class RouteDecoratorTest extends TestCase
             '_method' => 'GET'
         ];
 
-        // App controller
         $routeDecorator = (new RouteDecorator(new Route('/test/template', $defaults)));
         $this->assertEquals($defaults['plugin'], $routeDecorator->getPlugin());
         $this->assertEquals($defaults['prefix'], $routeDecorator->getPrefix());
@@ -29,11 +31,21 @@ class RouteDecoratorTest extends TestCase
             'SwaggerBakeTest\App\Controller\DepartmentsController',
             $routeDecorator->getControllerFqn()
         );
+    }
 
-        // Plugin controller + multiple methods
-        $defaults['plugin'] = 'Demo';
-        $defaults['_method'] = ['GET', 'POST'];
-        $defaults['controller'] = 'Test';
+    /**
+     * When `__construct` is called and the route is for a plugin, the controller FQN is found.
+     */
+    public function test_with_plugin(): void
+    {
+        $defaults = [
+            'plugin' => 'Demo',
+            'prefix' => null,
+            'controller' => 'Test',
+            'action' => 'index',
+            '_method' => ['GET', 'POST']
+        ];
+
         $routeDecorator = (new RouteDecorator(new Route('/test/template', $defaults)));
         $this->assertEquals($defaults['plugin'], $routeDecorator->getPlugin());
         $this->assertEquals($defaults['_method'], $routeDecorator->getMethods());
@@ -43,6 +55,9 @@ class RouteDecoratorTest extends TestCase
         );
     }
 
+    /**
+     * When `__construct` is called and the route template uses snake_case, the Controller FQN is found.
+     */
     public function test_snake_case_controller_names(): void
     {
         $routeDecorator = (new RouteDecorator(new Route('/department_employees', [
@@ -52,6 +67,27 @@ class RouteDecoratorTest extends TestCase
         $this->assertIsString($routeDecorator->getControllerFqn());
         $this->assertEquals(
             'SwaggerBakeTest\\App\\Controller\\DepartmentEmployeesController',
+            $routeDecorator->getControllerFqn()
+        );
+    }
+
+    /**
+     * When `__construct` is called with a route prefix containing a forward `/` slash, the slash is flipped `\` and
+     * the controller FQN is found.
+     */
+    public function test_prefixes_with_forward_slash(): void
+    {
+        $defaults = [
+            'plugin' => null,
+            'prefix' => 'Api/V1',
+            'controller' => 'Departments',
+            'action' => 'index',
+            '_method' => 'GET',
+        ];
+        $routeDecorator = (new RouteDecorator(new Route('/departments', $defaults)));
+        $this->assertIsString($routeDecorator->getControllerFqn());
+        $this->assertEquals(
+            'SwaggerBakeTest\\App\\Controller\\Api\V1\DepartmentsController',
             $routeDecorator->getControllerFqn()
         );
     }

--- a/tests/test_app/src/Controller/Api/V1/DepartmentsController.php
+++ b/tests/test_app/src/Controller/Api/V1/DepartmentsController.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace SwaggerBakeTest\App\Controller\Api\V1;
+
+use SwaggerBakeTest\App\Controller\AppController;
+
+class DepartmentsController extends AppController
+{
+    /**
+     * @see \SwaggerBake\Test\TestCase\Lib\Route\RouteDecoratorTest::test_prefixes_with_forward_slash()
+     */
+    public function index(): void
+    {
+
+    }
+}


### PR DESCRIPTION
Ref #478 

Fixes setting RouteDecorator::controllerFqn when route prefix contains a forward slash.