### PR TITLE
Add trait to suppress dynamic properties error

### DIFF
--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -14,6 +14,7 @@ use SwaggerBake\Lib\Utility\ArrayUtility;
  * @see https://swagger.io/docs/specification/data-models/
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
+#[\AllowDynamicProperties]
 class Schema implements JsonSerializable, SchemaInterface
 {
     use SchemaTrait;

--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -14,6 +14,7 @@ use SwaggerBake\Lib\Utility\ArrayUtility;
  * @see https://swagger.io/docs/specification/data-models/
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
+/** @phpstan-ignore-next-line */
 #[\AllowDynamicProperties]
 class Schema implements JsonSerializable, SchemaInterface
 {


### PR DESCRIPTION
(I figured out what I was doing wrong, the trait is in the PHP global namespace so you have to prefix it with a backslash.)

This references bug #500 

Three solutions exist that we know of to suppress the error:
1. Turning debug mode off in your Cake app so deprecation errors get swallowed
2. Adding `#[\AllowDynamicProperties]` to `src/Lib/OpenApi/Schema.php`
3. Same class as above, but extending stdClass like this: `class Schema extends \stdClass implements JsonSerializable, SchemaInterface` (again, note backslash)

This PR implements **Solution 2**. I'm also using Solution 1 in production (because I don't run debug mode in prod). I'm unsure of all the ramifications of Solution 3 (extending stdClass sounds like it comes with a lot of baggage) so I didn't go that route.

Important note: implementing `__get()` and `__set()` does _not_ suppress the deprecation if there is any codepath in your class that still does `$this->{$property} = $value`. Therefore, I think the long-term solution ought to be something like Cake's `InstanceConfig` trait or some other similar lib for storing dynamic hashmaps of values.