### PR TITLE
Issue #508: Fix OpenApiResponse bug on schemaType: 'array'+ref

### DIFF
--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -115,9 +115,16 @@ class OperationResponse
     private function addResponseRef(Response $response, string $mimeType, OpenApiResponse $openApiResponse): bool
     {
         if ($openApiResponse->ref) {
-            $schema = (new Schema())
-                ->setAllOf([['$ref' => $openApiResponse->ref]])
-                ->setType($openApiResponse->schemaType);
+            if ($openApiResponse->schemaType == 'array') {
+                $schema = (new Schema())
+                    ->setItems(['$ref' => $openApiResponse->ref])
+                    ->setType($openApiResponse->schemaType);
+            }
+            else {
+                $schema = (new Schema())
+                    ->setAllOf([['$ref' => $openApiResponse->ref]])
+                    ->setType($openApiResponse->schemaType);
+            }
 
             $response->pushContent(new Content($mimeType, $schema));
             $this->operation->pushResponse($response);


### PR DESCRIPTION
This fix should solve the problem.
Please refer to the issue.
https://github.com/cnizzardini/cakephp-swagger-bake/issues/508

