### PR TITLE
Adds support for json type

### DIFF
--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -38,6 +38,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
     private bool $requirePresenceOnUpdate = false;
     private array $items = [];
     private ?string $refEntity = null;
+    private array $oneOf = [];
 
     /**
      * @param string|null $name Name of the property, this is used for internal storage and must be unique. If not set
@@ -100,7 +101,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             [
                 'format','title','description','multipleOf','minimum','maximum','minLength','maxLength','pattern',
                 'minItems','maxItems','minProperties','maxProperties','items','enum','default','exclusiveMinimum',
-                'exclusiveMaximum','uniqueItems','nullable','type',
+                'exclusiveMaximum','uniqueItems','nullable','type','oneOf'
             ]
         );
 
@@ -305,5 +306,21 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
         $this->isHidden = $isHidden;
 
         return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOneOf(): array
+    {
+        return $this->oneOf;
+    }
+
+    /**
+     * @param array $oneOf
+     */
+    public function setOneOf(array $oneOf): void
+    {
+        $this->oneOf = $oneOf;
     }
 }

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -101,7 +101,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             [
                 'format','title','description','multipleOf','minimum','maximum','minLength','maxLength','pattern',
                 'minItems','maxItems','minProperties','maxProperties','items','enum','default','exclusiveMinimum',
-                'exclusiveMaximum','uniqueItems','nullable','type','oneOf'
+                'exclusiveMaximum','uniqueItems','nullable','type','oneOf',
             ]
         );
 
@@ -317,10 +317,13 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
     }
 
     /**
-     * @param array $oneOf
+     * @param array $oneOf OpenAPI oneOf syntax
+     * @return $this
      */
-    public function setOneOf(array $oneOf): void
+    public function setOneOf(array $oneOf)
     {
         $this->oneOf = $oneOf;
+
+        return $this;
     }
 }

--- a/src/Lib/OpenApi/SchemaTrait.php
+++ b/src/Lib/OpenApi/SchemaTrait.php
@@ -23,12 +23,12 @@ trait SchemaTrait
     }
 
     /**
-     * @param string $type Type
+     * @param string|null $type Type
      * @return $this
      */
-    public function setType(string $type)
+    public function setType(?string $type)
     {
-        if (!in_array($type, OpenApiDataType::TYPES)) {
+        if ($type !== null && !in_array($type, OpenApiDataType::TYPES)) {
             throw new InvalidArgumentException(
                 "Schema type of `$type` is invalid. Must be one of: " .
                 implode(',', OpenApiDataType::TYPES)

--- a/src/Lib/Schema/SchemaPropertyFactory.php
+++ b/src/Lib/Schema/SchemaPropertyFactory.php
@@ -43,8 +43,11 @@ class SchemaPropertyFactory
             ->setFormat(DataTypeConversion::toFormat($property->getType()))
             ->setIsHidden($property->isHidden());
 
+        /*
+         * Convert `json` types to oneOf: object or array
+         */
         if ($schemaProperty->getType() === 'json') {
-            $schemaProperty->setType('object');
+            $schemaProperty->setType(null);
             $schemaProperty->setOneOf([['type' => 'object'], ['type' => 'array', 'items' => []]]);
         }
 

--- a/src/Lib/Schema/SchemaPropertyFactory.php
+++ b/src/Lib/Schema/SchemaPropertyFactory.php
@@ -43,6 +43,11 @@ class SchemaPropertyFactory
             ->setFormat(DataTypeConversion::toFormat($property->getType()))
             ->setIsHidden($property->isHidden());
 
+        if ($schemaProperty->getType() === 'json') {
+            $schemaProperty->setType('object');
+            $schemaProperty->setOneOf([['type' => 'object'], ['type' => 'array', 'items' => []]]);
+        }
+
         /*
          * Per OpenAPI spec, only one of `writeOnly` and `readOnly` may be set to true.
          *

--- a/src/Lib/Utility/DataTypeConversion.php
+++ b/src/Lib/Utility/DataTypeConversion.php
@@ -18,17 +18,18 @@ class DataTypeConversion
      */
     public static function toType(string $cakeType): string
     {
-        $typeMap = [
+        $openApiTypeMap = [
             // openapi type => ['cake','types']
             'integer' => ['int','integer','tinyinteger','smallinteger','biginteger','mediuminteger'],
             'number' => ['decimal','float'],
             'string' => ['uuid','text','varchar','char','date','time','datetime','timestampfractional','timestamp'],
             'boolean' => ['bool','boolean'],
+            'json' => ['json']
         ];
 
-        foreach ($typeMap as $type => $types) {
-            if (in_array($cakeType, $types)) {
-                return $type;
+        foreach ($openApiTypeMap as $openApiType => $cakeTypes) {
+            if (in_array($cakeType, $cakeTypes)) {
+                return $openApiType;
             }
         }
 

--- a/src/Lib/Utility/DataTypeConversion.php
+++ b/src/Lib/Utility/DataTypeConversion.php
@@ -24,7 +24,7 @@ class DataTypeConversion
             'number' => ['decimal','float'],
             'string' => ['uuid','text','varchar','char','date','time','datetime','timestampfractional','timestamp'],
             'boolean' => ['bool','boolean'],
-            'json' => ['json']
+            'json' => ['json'],
         ];
 
         foreach ($openApiTypeMap as $openApiType => $cakeTypes) {

--- a/src/Lib/Utility/OpenApiDataType.php
+++ b/src/Lib/Utility/OpenApiDataType.php
@@ -16,6 +16,7 @@ class OpenApiDataType
     public const NUMBER = 'number';
     public const OBJECT = 'object';
     public const STRING = 'string';
+    public const JSON = 'json';
     public const EMPTY = '';
 
     /**
@@ -28,6 +29,7 @@ class OpenApiDataType
         self::NUMBER,
         self::OBJECT,
         self::STRING,
+        self::JSON,
         self::EMPTY,
     ];
 }

--- a/tests/Fixture/DepartmentsFixture.php
+++ b/tests/Fixture/DepartmentsFixture.php
@@ -17,8 +17,9 @@ class DepartmentsFixture extends TestFixture
      */
     // phpcs:disable
     public $fields = [
-        'id' => ['type' => 'smallinteger', 'length' => 6, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'name' => ['type' => 'string', 'length' => 64, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
+        'id' => ['type' => 'smallinteger', 'length' => 6, 'unsigned' => false, 'null' => false, 'default' => null,],
+        'name' => ['type' => 'string', 'length' => 64, 'null' => false, 'default' => null,],
+        'json_field' => ['type' => 'json', 'null' => true, 'default' => null,],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
             'dept_name' => ['type' => 'unique', 'columns' => ['name'], 'length' => []],
@@ -40,6 +41,7 @@ class DepartmentsFixture extends TestFixture
             [
                 'id' => 1,
                 'name' => 'Lorem ipsum dolor sit amet',
+                'json' => '{"id": 123, "hello": "world"}'
             ],
         ];
         parent::init();

--- a/tests/TestCase/Lib/Schema/SchemaFactoryTest.php
+++ b/tests/TestCase/Lib/Schema/SchemaFactoryTest.php
@@ -14,6 +14,11 @@ use SwaggerBakeTest\App\Model\Table\DepartmentsTable;
 
 class SchemaFactoryTest extends TestCase
 {
+    /** @inheritdoc  */
+    public $fixtures = [
+        'plugin.SwaggerBake.Departments',
+    ];
+
     public function test_create_schema(): void
     {
         $connection = ConnectionManager::get('default');
@@ -25,6 +30,7 @@ class SchemaFactoryTest extends TestCase
 
         /** @var SchemaProperty[] $properties */
         $properties = $schema->getProperties();
+
         $this->assertEquals('this_is_a_unit_test_for_description', $properties['name']->getDescription());
     }
 

--- a/tests/TestCase/Lib/Schema/SchemaPropertyFactoryTest.php
+++ b/tests/TestCase/Lib/Schema/SchemaPropertyFactoryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SwaggerBake\Test\TestCase\Lib\Schema;
+
+use Cake\TestSuite\TestCase;
+use Cake\Validation\Validator;
+use MixerApi\Core\Model\ModelProperty;
+use SwaggerBake\Lib\Schema\SchemaPropertyFactory;
+
+class SchemaPropertyFactoryTest extends TestCase
+{
+    /**
+     * When a column is a CakePHP/MySQL type of `json`, then it is created as oneOf: object or array in OpenAPI
+     */
+    public function test_json_field_type_is_openapi_oneof(): void
+    {
+        $property = (new SchemaPropertyFactory(new Validator()))->create(
+            (new ModelProperty())->setName('json_field')->setType('json')
+        );
+
+        $this->assertNull($property->getType());
+        $this->assertEquals([['type' => 'object'], ['type' => 'array', 'items' => []]], $property->getOneOf());
+    }
+}

--- a/tests/TestCase/Lib/Utility/DataTypeConversionTest.php
+++ b/tests/TestCase/Lib/Utility/DataTypeConversionTest.php
@@ -4,15 +4,10 @@ namespace SwaggerBake\Test\TestCase\Lib\Utility;
 
 use Cake\TestSuite\TestCase;
 use SwaggerBake\Lib\Utility\DataTypeConversion;
+use SwaggerBake\Lib\Utility\OpenApiDataType;
 
 class DataTypeConversionTest extends TestCase
 {
-    // OpenAPI Types:
-    private const OA_TYPE_INTEGER = 'integer';
-    private const OA_TYPE_NUMBER = 'number';
-    private const OA_TYPE_STRING = 'string';
-    private const OA_TYPE_BOOLEAN = 'boolean';
-
     // OpenAPI Formats:
     private const OA_FORMAT_INT64 = 'int64';
     private const OA_FORMAT_INT32 = 'int32';
@@ -21,25 +16,26 @@ class DataTypeConversionTest extends TestCase
     public function testToType(): void
     {
         $types = [
-            'int' => self::OA_TYPE_INTEGER,
-            'integer' => self::OA_TYPE_INTEGER,
-            'tinyinteger' => self::OA_TYPE_INTEGER,
-            'smallinteger' => self::OA_TYPE_INTEGER,
-            'biginteger' => self::OA_TYPE_INTEGER,
-            'mediuminteger' => self::OA_TYPE_INTEGER,
-            'decimal' => self::OA_TYPE_NUMBER,
-            'float' => self::OA_TYPE_NUMBER,
-            'uuid' => self::OA_TYPE_STRING,
-            'text' => self::OA_TYPE_STRING,
-            'varchar' => self::OA_TYPE_STRING,
-            'char' => self::OA_TYPE_STRING,
-            'date' => self::OA_TYPE_STRING,
-            'time' => self::OA_TYPE_STRING,
-            'datetime' => self::OA_TYPE_STRING,
-            'boolean' => self::OA_TYPE_BOOLEAN,
-            'bool' => self::OA_TYPE_BOOLEAN,
-            'timestamp' => self::OA_TYPE_STRING,
-            'timestampfractional' => self::OA_TYPE_STRING,
+            'int' => OpenApiDataType::INTEGER,
+            'integer' => OpenApiDataType::INTEGER,
+            'tinyinteger' => OpenApiDataType::INTEGER,
+            'smallinteger' => OpenApiDataType::INTEGER,
+            'biginteger' => OpenApiDataType::INTEGER,
+            'mediuminteger' => OpenApiDataType::INTEGER,
+            'decimal' => OpenApiDataType::NUMBER,
+            'float' => OpenApiDataType::NUMBER,
+            'uuid' => OpenApiDataType::STRING,
+            'text' => OpenApiDataType::STRING,
+            'varchar' => OpenApiDataType::STRING,
+            'char' => OpenApiDataType::STRING,
+            'date' => OpenApiDataType::STRING,
+            'time' => OpenApiDataType::STRING,
+            'datetime' => OpenApiDataType::STRING,
+            'boolean' => OpenApiDataType::BOOLEAN,
+            'bool' => OpenApiDataType::BOOLEAN,
+            'timestamp' => OpenApiDataType::STRING,
+            'timestampfractional' => OpenApiDataType::STRING,
+            'json' => OpenApiDataType::JSON
         ];
 
         foreach ($types as $dbType => $openApiType) {
@@ -63,9 +59,9 @@ class DataTypeConversionTest extends TestCase
             'decimal' => self::OA_FORMAT_FLOAT,
             'float' => self::OA_FORMAT_FLOAT,
             'uuid' => 'uuid',
-            'text' => self::OA_TYPE_STRING,
-            'varchar' => self::OA_TYPE_STRING,
-            'char' => self::OA_TYPE_STRING,
+            'text' => OpenApiDataType::STRING,
+            'varchar' => OpenApiDataType::STRING,
+            'char' => OpenApiDataType::STRING,
             'date' => 'date',
             'time' => 'time',
             'datetime' => 'date-time',

--- a/tests/test_app/src/Model/Table/DepartmentEmployeesTable.php
+++ b/tests/test_app/src/Model/Table/DepartmentEmployeesTable.php
@@ -11,22 +11,22 @@ use Cake\Validation\Validator;
 /**
  * DepartmentEmployees Model
  *
- * @property \SwaggerBake\Test\Model\Table\EmployeesTable&\Cake\ORM\Association\BelongsTo $Employees
- * @property \SwaggerBake\Test\Model\Table\DepartmentsTable&\Cake\ORM\Association\BelongsTo $Departments
+ * @property \SwaggerBakeTest\SwaggerBakeTest\App\Model\Table\EmployeesTable&\Cake\ORM\Association\BelongsTo $Employees
+ * @property \SwaggerBakeTest\SwaggerBakeTest\App\Model\Table\DepartmentsTable&\Cake\ORM\Association\BelongsTo $Departments
  *
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee newEmptyEntity()
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee newEntity(array $data, array $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee[] newEntities(array $data, array $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee get($primaryKey, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee findOrCreate($search, ?callable $callback = null, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee[] patchEntities(iterable $entities, array $data, array $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\DepartmentEmployee[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee newEmptyEntity()
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee newEntity(array $data, array $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee[] newEntities(array $data, array $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee get($primaryKey, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\DepartmentEmployee[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
  */
 class DepartmentEmployeesTable extends Table
 {

--- a/tests/test_app/src/Model/Table/DepartmentsTable.php
+++ b/tests/test_app/src/Model/Table/DepartmentsTable.php
@@ -11,21 +11,21 @@ use Cake\Validation\Validator;
 /**
  * Departments Model
  *
- * @property \SwaggerBake\Test\Model\Table\DepartmentEmployeesTable&\Cake\ORM\Association\HasMany $DepartmentEmployees
+ * @property \SwaggerBakeTest\SwaggerBakeTest\App\Model\Table\DepartmentEmployeesTable&\Cake\ORM\Association\HasMany $DepartmentEmployees
  *
- * @method \SwaggerBake\Test\Model\Entity\Department newEmptyEntity()
- * @method \SwaggerBake\Test\Model\Entity\Department newEntity(array $data, array $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department[] newEntities(array $data, array $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department get($primaryKey, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department findOrCreate($search, ?callable $callback = null, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department[] patchEntities(iterable $entities, array $data, array $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
- * @method \SwaggerBake\Test\Model\Entity\Department[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department newEmptyEntity()
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department newEntity(array $data, array $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department[] newEntities(array $data, array $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department get($primaryKey, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\SwaggerBakeTest\App\Model\Entity\Department[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
  */
 class DepartmentsTable extends Table
 {

--- a/tests/test_app/src/Model/Table/EmployeeSalariesTable.php
+++ b/tests/test_app/src/Model/Table/EmployeeSalariesTable.php
@@ -11,21 +11,21 @@ use Cake\Validation\Validator;
 /**
  * EmployeeSalaries Model
  *
- * @property \App\Model\Table\EmployeesTable&\Cake\ORM\Association\BelongsTo $Employees
+ * @property \SwaggerBakeTest\App\Model\Table\EmployeesTable&\Cake\ORM\Association\BelongsTo $Employees
  *
- * @method \App\Model\Entity\EmployeeSalary newEmptyEntity()
- * @method \App\Model\Entity\EmployeeSalary newEntity(array $data, array $options = [])
- * @method \App\Model\Entity\EmployeeSalary[] newEntities(array $data, array $options = [])
- * @method \App\Model\Entity\EmployeeSalary get($primaryKey, $options = [])
- * @method \App\Model\Entity\EmployeeSalary findOrCreate($search, ?callable $callback = null, $options = [])
- * @method \App\Model\Entity\EmployeeSalary patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method \App\Model\Entity\EmployeeSalary[] patchEntities(iterable $entities, array $data, array $options = [])
- * @method \App\Model\Entity\EmployeeSalary|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \App\Model\Entity\EmployeeSalary saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \App\Model\Entity\EmployeeSalary[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
- * @method \App\Model\Entity\EmployeeSalary[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
- * @method \App\Model\Entity\EmployeeSalary[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
- * @method \App\Model\Entity\EmployeeSalary[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary newEmptyEntity()
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary newEntity(array $data, array $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary[] newEntities(array $data, array $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary get($primaryKey, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeSalary[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
  */
 class EmployeeSalariesTable extends Table
 {

--- a/tests/test_app/src/Model/Table/EmployeeTitlesTable.php
+++ b/tests/test_app/src/Model/Table/EmployeeTitlesTable.php
@@ -11,21 +11,21 @@ use Cake\Validation\Validator;
 /**
  * EmployeeTitles Model
  *
- * @property \App\Model\Table\EmployeesTable&\Cake\ORM\Association\BelongsTo $Employees
+ * @property \SwaggerBakeTest\App\Model\Table\EmployeesTable&\Cake\ORM\Association\BelongsTo $Employees
  *
- * @method \App\Model\Entity\EmployeeTitle newEmptyEntity()
- * @method \App\Model\Entity\EmployeeTitle newEntity(array $data, array $options = [])
- * @method \App\Model\Entity\EmployeeTitle[] newEntities(array $data, array $options = [])
- * @method \App\Model\Entity\EmployeeTitle get($primaryKey, $options = [])
- * @method \App\Model\Entity\EmployeeTitle findOrCreate($search, ?callable $callback = null, $options = [])
- * @method \App\Model\Entity\EmployeeTitle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method \App\Model\Entity\EmployeeTitle[] patchEntities(iterable $entities, array $data, array $options = [])
- * @method \App\Model\Entity\EmployeeTitle|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \App\Model\Entity\EmployeeTitle saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
- * @method \App\Model\Entity\EmployeeTitle[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
- * @method \App\Model\Entity\EmployeeTitle[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
- * @method \App\Model\Entity\EmployeeTitle[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
- * @method \App\Model\Entity\EmployeeTitle[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle newEmptyEntity()
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle newEntity(array $data, array $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle[] newEntities(array $data, array $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle get($primaryKey, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \SwaggerBakeTest\App\Model\Entity\EmployeeTitle[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
  */
 class EmployeeTitlesTable extends Table
 {


### PR DESCRIPTION
Adds support for CakePHP/MySQL data type of JSON with the following OpenAPI schema:

```yaml
json_field:
  oneOf:
    - type: object
    - type: array
      items: []
```

Ref: #507 

Misc: Cleans up some annotations in tests.