### PR TITLE
Fixes OpenApiSchemaProperty(name: 'propert_name', type: 'array') not working

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -589,6 +589,7 @@ your entity. You can add adhoc attributes as needed and optionally combine with
 | minProperties      | ?int `null`       | Y          | http://spec.openapis.org/oas/v3.0.3#properties                                                         |
 | maxProperties      | ?int `null`       | Y          | http://spec.openapis.org/oas/v3.0.3#properties                                                         |
 | enum               | array `[]`        | Y          | An enumerated list of of options for the value                                                         |
+| items              | array `[]`        | Y          | For use with array schema properties.                                                                  |
 
 ```php
 #[OpenApiSchemaProperty(name: 'example_one', minLength: 5, maxLength: 10)]

--- a/src/Lib/Attribute/AbstractSchemaProperty.php
+++ b/src/Lib/Attribute/AbstractSchemaProperty.php
@@ -41,6 +41,8 @@ abstract class AbstractSchemaProperty
      * @param int|null $minProperties See OpenAPI documentation
      * @param int|null $maxProperties See OpenAPI documentation
      * @param array $enum An enumerated list of values that can be accepted
+     * @param array $items For use with array type only, will be ignored otherwise. See OpenAPI documentation for
+     *  setting items on array properties.
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -70,6 +72,7 @@ abstract class AbstractSchemaProperty
         public ?int $minProperties = null,
         public ?int $maxProperties = null,
         public array $enum = [],
+        public array $items = []
     ) {
     }
 
@@ -89,6 +92,10 @@ abstract class AbstractSchemaProperty
             ->setWriteOnly($this->isWriteOnly)
             ->setRequired($this->isRequired)
             ->setEnum($this->enum ?? []);
+
+        if ($schemaProperty->getType() === 'array') {
+            $schemaProperty->setItems($this->items ?? []);
+        }
 
         $properties = [
             'maxLength',

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -43,7 +43,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
     /**
      * @param string|null $name Name of the property, this is used for internal storage and must be unique. If not set
      *      in the constructor then this must be defined with the setter `setName`.
-     * @param string $type The OpenAPI data type (e.g. string, integer, boolean etc.). Defaults to string.
+     * @param string|null $type The OpenAPI data type (e.g. string, integer, boolean etc.). Defaults to string.
      * @param string|null $format An optional OpenAPI data format (i.e. int32, date-time, uuid etc.). Defaults to null.
      * @param string|null $description An optional description. Defaults to null.
      * @param mixed $example An optional example. Defaults to null.

--- a/tests/TestCase/Lib/Attribute/OpenApiSchemaPropertyTest.php
+++ b/tests/TestCase/Lib/Attribute/OpenApiSchemaPropertyTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SwaggerBake\Test\TestCase\Lib\Attribute;
+
+use Cake\TestSuite\TestCase;
+use SwaggerBake\Lib\Attribute\OpenApiSchemaProperty;
+
+class OpenApiSchemaPropertyTest extends TestCase
+{
+    /**
+     * Specifying a type of array will always set the OpenAPI items property.
+     *
+     * @return void
+     */
+    public function test_type_array(): void
+    {
+        $property = (new OpenApiSchemaProperty(name: 'test', type: 'array'))->create();
+        $this->assertEquals([], $property->getItems());
+
+        $property = (new OpenApiSchemaProperty(name: 'test', type: 'array', items: ['type' => 'object']))->create();
+        $this->assertEquals(['type' => 'object'], $property->getItems());
+    }
+}


### PR DESCRIPTION
Resolves: #512 

The attribute now accepts an `items` property for setting array properties, otherwise it defaults to an empty array.