### PR TITLE
Mepeiso/add false option to associations white list

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -503,7 +503,13 @@ add the `#[OpenApiSchema]` attribute to your schema class to change the default 
 #### Associations
 
 The association property allows you to include associations defined in your Table class within your OpenAPI response
-sample schema. To include all immediately associated tables (depth of one):
+sample schema. To not include associations:
+
+```php
+#[OpenApiResponse(associations: false)]
+```
+
+To include all immediately associated tables (depth of one):
 
 ```php
 #[OpenApiResponse(associations: [])]

--- a/src/Lib/Operation/OperationResponseAssociation.php
+++ b/src/Lib/Operation/OperationResponseAssociation.php
@@ -71,6 +71,14 @@ class OperationResponseAssociation
                 ->setProperties([]);
         }
 
+        // if $associations['whiteList'] is set to false no associations need to be loaded
+        if (isset($associations['whiteList']) && $associations['whiteList'] === false) {
+            $entity = $this->inflector::singularize($table->getAlias());
+            $schema = $this->getOrCreateAssociatedSchema($entity, $table->getAlias());
+
+            return $schema;
+        }
+
         if (!isset($associations['whiteList']) || !count($associations['whiteList'])) {
             $associations['whiteList'] = [];
             /** @var \Cake\ORM\Association $association */

--- a/tests/TestCase/Lib/Operation/OperationResponseAssociationTest.php
+++ b/tests/TestCase/Lib/Operation/OperationResponseAssociationTest.php
@@ -106,6 +106,25 @@ class OperationResponseAssociationTest extends TestCase
         $this->assertArrayHasKey('employee_titles', $schema->getProperties()['employee']->getProperties());
     }
 
+    public function test_false_white_list(): void
+    {
+        $assoc = new OperationResponseAssociation(
+            (new SwaggerFactory($this->config, new RouteScanner($this->router, $this->config)))->create(),
+            $this->routes['employees:view'],
+            null
+        );
+
+        $schema = $assoc->build(new OpenApiResponse(
+            schemaType: 'object',
+            associations: ['whiteList' => false]
+        ));
+
+        $this->assertInstanceOf(Schema::class, $schema);
+        $this->assertArrayNotHasKey('department_employees', $schema->getProperties());
+        $this->assertArrayNotHasKey('employee_salaries', $schema->getProperties());
+        $this->assertArrayNotHasKey('employee_titles', $schema->getProperties());
+    }
+
     public function test_null_schema(): void
     {
         $assoc = new OperationResponseAssociation(


### PR DESCRIPTION
`#[OpenApiResponse(schemaType: 'array', associations: ['whiteList' => false])]`

Will allow not load the associations. So we have a way to get the default schema without the associations loaded.

Added strict  `=== false` here: https://github.com/manuelpeiso/cakephp-swagger-bake/blob/e4c069ae05ec2fd9ef5c293fe806ad0dfd053b45/src/Lib/Operation/OperationResponseAssociation.php#L74

New test `test_false_white_list` created here: https://github.com/manuelpeiso/cakephp-swagger-bake/blob/e4c069ae05ec2fd9ef5c293fe806ad0dfd053b45/tests/TestCase/Lib/Operation/OperationResponseAssociationTest.php#L109

Documentation was updated to add new option.

Resolves: #537 