### PR TITLE
Removing schema and routes check when request comes from web and hotReload is set to false to avoid unnecessary use of resources.

### DIFF
--- a/src/Lib/Model/ModelScanner.php
+++ b/src/Lib/Model/ModelScanner.php
@@ -46,6 +46,10 @@ class ModelScanner
     {
         $return = [];
 
+        if (!$this->config->isHotReload() && PHP_SAPI !== 'cli') {
+            return $return;
+        }
+
         $connection = ConnectionManager::get($this->config->getConnectionName());
         $namespaces = $this->config->getNamespaces();
 

--- a/src/Lib/Route/RouteScanner.php
+++ b/src/Lib/Route/RouteScanner.php
@@ -28,9 +28,9 @@ class RouteScanner
     private array $routes;
 
     /**
-     * @var \SwaggerBake\Lib\Configuration
+     * @var bool
      */
-    private Configuration $config;
+    private bool $isHotReload;
 
     /**
      * @param \Cake\Routing\Router $router CakePHP Router
@@ -38,7 +38,7 @@ class RouteScanner
      */
     public function __construct(private Router $router, Configuration $config)
     {
-        $this->config = $config;
+        $this->isHotReload = $config->isHotReload();
         $this->prefix = $config->getPrefix();
         $this->loadRoutes();
     }
@@ -64,9 +64,9 @@ class RouteScanner
 
         $routes = [];
 
-        if (!$this->config->isHotReload() && PHP_SAPI !== 'cli') {
+        if (!$this->isHotReload && PHP_SAPI !== 'cli') {
             $this->routes = $routes;
-            
+
             return;
         }
 

--- a/src/Lib/Route/RouteScanner.php
+++ b/src/Lib/Route/RouteScanner.php
@@ -66,6 +66,7 @@ class RouteScanner
 
         if (!$this->config->isHotReload() && PHP_SAPI !== 'cli') {
             $this->routes = $routes;
+            
             return;
         }
 

--- a/src/Lib/Route/RouteScanner.php
+++ b/src/Lib/Route/RouteScanner.php
@@ -28,11 +28,17 @@ class RouteScanner
     private array $routes;
 
     /**
+     * @var \SwaggerBake\Lib\Configuration
+     */
+    private Configuration $config;
+
+    /**
      * @param \Cake\Routing\Router $router CakePHP Router
      * @param \SwaggerBake\Lib\Configuration $config Swagger Configuration
      */
     public function __construct(private Router $router, Configuration $config)
     {
+        $this->config = $config;
         $this->prefix = $config->getPrefix();
         $this->loadRoutes();
     }
@@ -57,6 +63,11 @@ class RouteScanner
         }
 
         $routes = [];
+
+        if (!$this->config->isHotReload() && PHP_SAPI !== 'cli') {
+            $this->routes = $routes;
+            return;
+        }
 
         foreach ($this->router::routes() as $route) {
             if (!$this->isRouteAllowed($route)) {


### PR DESCRIPTION
The SwaggerFactory creates an instance of RouteScanner and also an instance of ModelScanner. No matter what, the RouteScanner is going to read all the routes and the ModelScanner is going to iterate over all the tables.
This behavior is quite rare when the hotReload is set to false, because the expected behavior would be to read the swagger.json and return the proper view (why to check routes and schema if we are not generating the swagger.json?)

This PR goal is to avoid this, avoid to load routes and schema in the swagger instance when the request is coming from the web and the hotReload configuration key is set to false.
The CLI requests are excluded because even when hotReload is set to false we need to check routes and schema when, for example, the command `bin/cake swagger bake` is execute.