### PR TITLE
Hidden properties take precedence in being hidden

### DIFF
--- a/src/Lib/Schema/SchemaFactory.php
+++ b/src/Lib/Schema/SchemaFactory.php
@@ -134,7 +134,9 @@ class SchemaFactory
         $factory = new SchemaPropertyFactory($this->validator, $docBlock);
 
         foreach ($model->getProperties() as $property) {
-            $return[$property->getName()] = $factory->create($property);
+            if (!$property->isHidden()) {
+                $return[$property->getName()] = $factory->create($property);
+            }
         }
 
         $return = array_merge($return, $this->getPropertyAnnotations($model));

--- a/tests/TestCase/Lib/SwaggerSchemaTest.php
+++ b/tests/TestCase/Lib/SwaggerSchemaTest.php
@@ -70,7 +70,7 @@ class SwaggerSchemaTest extends TestCase
         $this->assertEquals('date', $employee['properties']['hire_date']['format']);
 
         $this->assertTrue($employee['properties']['read']['readOnly']);
-        $this->assertTrue($employee['properties']['write']['writeOnly']);
+        $this->assertArrayNotHasKey('write', $employee['properties']);
         $this->assertArrayNotHasKey('hide', $employee['properties']);
 
         foreach (['birth_date', 'first_name', 'last_name', 'gender', 'hire_date',] as $property) {


### PR DESCRIPTION
Resolves #546

Hidden properties were correctly not showing in operation response sample, but still displaying in schema sample. This hides them always.