### PR TITLE
add ordering paramter to openApiPaginator

### DIFF
--- a/assets/x-swagger-bake.yaml
+++ b/assets/x-swagger-bake.yaml
@@ -14,6 +14,21 @@ x-swagger-bake:
         required: false
         schema:
           type: integer
+      paginatorOrder:
+        name: order
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+                example: name
+              dir:
+                type: string
+                example: asc
       paginatorSort:
         name: sort
         in: query

--- a/src/Lib/Operation/OperationQueryParameter.php
+++ b/src/Lib/Operation/OperationQueryParameter.php
@@ -74,6 +74,7 @@ class OperationQueryParameter
         $this->operation->pushRefParameter('#/x-swagger-bake/components/parameters/paginatorPage');
         $this->operation->pushRefParameter('#/x-swagger-bake/components/parameters/paginatorLimit');
         $this->pushSortParameter($paginator);
+        $this->operation->pushRefParameter('#/x-swagger-bake/components/parameters/paginatorOrder');
         $this->operation->pushRefParameter('#/x-swagger-bake/components/parameters/paginatorDirection');
     }
 

--- a/tests/TestCase/Lib/Operation/OperationQueryParameterTest.php
+++ b/tests/TestCase/Lib/Operation/OperationQueryParameterTest.php
@@ -109,7 +109,7 @@ class OperationQueryParameterTest extends TestCase
         $operation = $operationQueryParam->getOperationWithQueryParameters();
 
         $parameters = $operation->getParameters();
-        $this->assertCount(11, $parameters);
+        $this->assertCount(12, $parameters);
     }
 
     public function test_openapi_paginator(): void


### PR DESCRIPTION
adding the possibility to order by array of fields, current behaviour adds sorting in one param 
`'#/x-swagger-bake/components/parameters/paginatorSort` ,

this creates an array of objects with
`
{
  "field": "name",
  "dir": "asc"
}
`
<img width="477" alt="Screenshot 2025-02-07 at 10 53 29" src="https://github.com/user-attachments/assets/320a7223-fcb1-413a-be33-61b74797dc6c" />
