### PR TITLE
Fix custom array schema

### DIFF
--- a/src/Command/CommandTrait.php
+++ b/src/Command/CommandTrait.php
@@ -30,7 +30,7 @@ trait CommandTrait
             Configure::load($config, 'default');
         } catch (CakeException $e) {
             throw new SwaggerBakeRunTimeException(
-                "SwaggerBake config file `$config` is missing or " . get_class($e) . ' ' . $e->getMessage()
+                "SwaggerBake config file `$config` is missing or " . get_class($e) . ' ' . $e->getMessage(),
             );
         }
 

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -42,7 +42,7 @@ class InstallCommand extends Command
         $continue = $io->ask(
             'If your API exists in a plugin or you have some other non-standard setup, please follow ' .
             'the manual installation steps. Do you want to continue?',
-            'Y'
+            'Y',
         );
 
         if (strtoupper($continue) !== 'Y') {

--- a/src/Lib/Attribute/AbstractOpenApiParameter.php
+++ b/src/Lib/Attribute/AbstractOpenApiParameter.php
@@ -83,7 +83,7 @@ abstract class AbstractOpenApiParameter
                 (new Schema())
                     ->setType($this->type)
                     ->setEnum($this->enum)
-                    ->setFormat($this->format)
+                    ->setFormat($this->format),
             );
 
         return $parameter;

--- a/src/Lib/Attribute/AbstractSchemaProperty.php
+++ b/src/Lib/Attribute/AbstractSchemaProperty.php
@@ -72,7 +72,7 @@ abstract class AbstractSchemaProperty
         public readonly ?int $minProperties = null,
         public readonly ?int $maxProperties = null,
         public readonly array $enum = [],
-        public readonly array $items = []
+        public readonly array $items = [],
     ) {
     }
 

--- a/src/Lib/Attribute/AttributeFactory.php
+++ b/src/Lib/Attribute/AttributeFactory.php
@@ -14,7 +14,7 @@ final class AttributeFactory
      */
     public function __construct(
         private Reflector $reflection,
-        private string $attributeClass
+        private string $attributeClass,
     ) {
     }
 

--- a/src/Lib/Attribute/OpenApiHeader.php
+++ b/src/Lib/Attribute/OpenApiHeader.php
@@ -43,7 +43,7 @@ class OpenApiHeader
         public readonly bool $explode = false,
         public readonly string $style = '',
         public readonly string|bool|int $example = '',
-        public readonly bool $allowEmptyValue = false
+        public readonly bool $allowEmptyValue = false,
     ) {
         if (empty($ref) && empty($name)) {
             throw new SwaggerBakeRunTimeException('One of ref or name must be defined');
@@ -55,8 +55,8 @@ class OpenApiHeader
                     'Invalid Data Type, given %s for %s but must be one of: %s',
                     $type,
                     $name,
-                    implode(',', OpenApiDataType::TYPES)
-                )
+                    implode(',', OpenApiDataType::TYPES),
+                ),
             );
         }
     }
@@ -81,7 +81,7 @@ class OpenApiHeader
                 (new Schema())
                     ->setType($this->type)
                     ->setEnum($this->enum)
-                    ->setFormat($this->format)
+                    ->setFormat($this->format),
             );
     }
 }

--- a/src/Lib/Attribute/OpenApiPaginator.php
+++ b/src/Lib/Attribute/OpenApiPaginator.php
@@ -16,7 +16,7 @@ class OpenApiPaginator
      */
     public function __construct(
         public readonly array $sortEnum = [],
-        public readonly bool $useSortTextInput = false
+        public readonly bool $useSortTextInput = false,
     ) {
     }
 }

--- a/src/Lib/Attribute/OpenApiPath.php
+++ b/src/Lib/Attribute/OpenApiPath.php
@@ -25,7 +25,7 @@ class OpenApiPath
         public readonly ?string $ref = null,
         public readonly ?string $summary = null,
         public readonly ?string $description = null,
-        public readonly array $tags = []
+        public readonly array $tags = [],
     ) {
     }
 }

--- a/src/Lib/Attribute/OpenApiPathParam.php
+++ b/src/Lib/Attribute/OpenApiPathParam.php
@@ -43,7 +43,7 @@ class OpenApiPathParam extends AbstractOpenApiParameter
             description: $description,
             example: $example,
             isRequired: $isRequired,
-            allowReserved: $allowReserved
+            allowReserved: $allowReserved,
         );
     }
 
@@ -62,7 +62,7 @@ class OpenApiPathParam extends AbstractOpenApiParameter
             ->setSchema(
                 (new Schema())
                     ->setType($this->type)
-                    ->setFormat($this->format)
+                    ->setFormat($this->format),
             );
     }
 }

--- a/src/Lib/Attribute/OpenApiQueryParam.php
+++ b/src/Lib/Attribute/OpenApiQueryParam.php
@@ -43,7 +43,7 @@ class OpenApiQueryParam
         public readonly bool $explode = false,
         public readonly string $style = '',
         public readonly string|bool|int $example = '',
-        public readonly bool $allowEmptyValue = false
+        public readonly bool $allowEmptyValue = false,
     ) {
         if (empty($ref) && empty($name)) {
             throw new SwaggerBakeRunTimeException('One of ref or name must be defined');
@@ -55,8 +55,8 @@ class OpenApiQueryParam
                     'Invalid Data Type, given %s for %s but must be one of: %s',
                     $type,
                     $name,
-                    implode(',', OpenApiDataType::TYPES)
-                )
+                    implode(',', OpenApiDataType::TYPES),
+                ),
             );
         }
     }
@@ -81,7 +81,7 @@ class OpenApiQueryParam
                 (new Schema())
                     ->setType($this->type)
                     ->setEnum($this->enum)
-                    ->setFormat($this->format)
+                    ->setFormat($this->format),
             );
     }
 }

--- a/src/Lib/Attribute/OpenApiRequestBody.php
+++ b/src/Lib/Attribute/OpenApiRequestBody.php
@@ -24,7 +24,7 @@ class OpenApiRequestBody
         public readonly string $description = '',
         public readonly array $mimeTypes = [],
         public readonly bool $required = true,
-        public readonly bool $ignoreCakeSchema = false
+        public readonly bool $ignoreCakeSchema = false,
     ) {
     }
 

--- a/src/Lib/Attribute/OpenApiResponse.php
+++ b/src/Lib/Attribute/OpenApiResponse.php
@@ -36,7 +36,7 @@ class OpenApiResponse
         if (is_array($associations)) {
             $this->associations = array_replace(
                 ['table' => null, 'whiteList' => null],
-                $associations
+                $associations,
             );
         }
     }

--- a/src/Lib/Attribute/OpenApiSchema.php
+++ b/src/Lib/Attribute/OpenApiSchema.php
@@ -39,11 +39,11 @@ class OpenApiSchema
     public function __construct(
         public readonly int $visibility = 1,
         public readonly ?string $title = null,
-        public readonly ?string $description = null
+        public readonly ?string $description = null,
     ) {
         if ($this->visibility < 1 || $this->visibility > 4) {
             throw new InvalidArgumentException(
-                'OpenApiSchema visibility must be 1 through 4. See class constants'
+                'OpenApiSchema visibility must be 1 through 4. See class constants',
             );
         }
     }

--- a/src/Lib/Attribute/OpenApiSecurity.php
+++ b/src/Lib/Attribute/OpenApiSecurity.php
@@ -19,7 +19,7 @@ class OpenApiSecurity
      */
     public function __construct(
         public readonly string $name,
-        public readonly array $scopes = []
+        public readonly array $scopes = [],
     ) {
     }
 }

--- a/src/Lib/Configuration.php
+++ b/src/Lib/Configuration.php
@@ -109,14 +109,14 @@ class Configuration
             throw new SwaggerBakeRunTimeException(
                 'SwaggerBake config missing. Have you added it to your `config/bootstrap.php`? ' . $e->getMessage(),
                 500,
-                $e
+                $e,
             );
         }
 
         foreach (['yml', 'json', 'webPath', 'prefix'] as $property) {
             if (!array_key_exists(key: $property, array: $config)) {
                 throw new InvalidArgumentException(
-                    "Property `$property` must be defined in your config/swagger_bake.php configuration file."
+                    "Property `$property` must be defined in your config/swagger_bake.php configuration file.",
                 );
             }
         }
@@ -131,8 +131,8 @@ class Configuration
                     sprintf(
                         'Method %s does not exist in class %s but is trying to be called.',
                         $setter,
-                        self::class
-                    )
+                        self::class,
+                    ),
                 );
             }
             $this->{$setter}($value);
@@ -155,7 +155,7 @@ class Configuration
     {
         $this->throwInvalidArgExceptionIfPrefixInvalid(
             $prefix,
-            "Invalid prefix: $prefix. Prefix must be a valid URI path such as `/` or `/api`."
+            "Invalid prefix: $prefix. Prefix must be a valid URI path such as `/` or `/api`.",
         );
 
         $this->prefix = $prefix;
@@ -184,8 +184,8 @@ class Configuration
                 sprintf(
                     "Invalid yml: `%s`. Value should start with a / an be relative to your 
                     applications ROOT. $message",
-                    $yml
-                )
+                    $yml,
+                ),
             );
         }
 
@@ -195,8 +195,8 @@ class Configuration
                 sprintf(
                     'A YML file is required but none was found at "%s". See "%s" for a sample file.',
                     $path,
-                    '$vendor/cnizzardini/cakephp-swagger-bake/assets/swagger.yml'
-                )
+                    '$vendor/cnizzardini/cakephp-swagger-bake/assets/swagger.yml',
+                ),
             );
         }
 
@@ -226,8 +226,8 @@ class Configuration
                 sprintf(
                     "Invalid json: `%s`. Value should start with a `/` and be relative to your 
                     applications ROOT. $message",
-                    $json
-                )
+                    $json,
+                ),
             );
         }
 
@@ -239,8 +239,8 @@ class Configuration
                     made to create %s, but permission was denied or the file path is bad. Either fix the file system 
                     permissions, create the file and/or both. $message",
                     $json,
-                    $path
-                )
+                    $path,
+                ),
             );
         }
 
@@ -267,7 +267,7 @@ class Configuration
             $webPath,
             "Invalid webPath: `$webPath`. webPath must be a valid web accessible path based e.g. /swagger.json. 
             Generally if your application serves the json file from something like https://example.com/swagger.json 
-            this value should be /swagger.json "
+            this value should be /swagger.json ",
         );
 
         $this->webPath = $webPath;
@@ -293,7 +293,7 @@ class Configuration
         $allowed = ['swagger','redoc'];
         if (!in_array($docType, $allowed)) {
             throw new InvalidArgumentException(
-                "Invalid docType: $docType. Doctype must be one of " . implode(', ', $allowed)
+                "Invalid docType: $docType. Doctype must be one of " . implode(', ', $allowed),
             );
         }
         $this->docType = $docType;
@@ -490,8 +490,8 @@ class Configuration
                 sprintf(
                     'Invalid connectionName supplied: %s. Must be one of %s',
                     $connectionName,
-                    implode(', ', $configuredConnections)
-                )
+                    implode(', ', $configuredConnections),
+                ),
             );
         }
 
@@ -524,8 +524,8 @@ class Configuration
                 sprintf(
                     'Invalid editActionMethod supplied: %s. Must be one of %s',
                     implode(', ', $results),
-                    implode(', ', $methods)
-                )
+                    implode(', ', $methods),
+                ),
             );
         }
 

--- a/src/Lib/Extension/CakeSearch/Extension.php
+++ b/src/Lib/Extension/CakeSearch/Extension.php
@@ -70,8 +70,8 @@ class Extension implements ExtensionInterface
                 sprintf(
                     'Extension `%s` could not be run because the subject must be an instance of `%s`',
                     self::class,
-                    Operation::class
-                )
+                    Operation::class,
+                ),
             );
         }
 
@@ -123,7 +123,7 @@ class Extension implements ExtensionInterface
         $parameter->setSchema(
             (new Schema())
                 ->setDescription($filter->getComparison())
-                ->setType('string')
+                ->setType('string'),
         );
 
         return $parameter;
@@ -143,7 +143,7 @@ class Extension implements ExtensionInterface
 
         $filters = $manager->getFilters($openApiSearch->collection);
         foreach ($filters as $filter) {
-            $decoratedFilters[] = (new FilterDecorator($filter));
+            $decoratedFilters[] = new FilterDecorator($filter);
         }
 
         return $decoratedFilters;
@@ -158,7 +158,7 @@ class Extension implements ExtensionInterface
         if (!$table->hasBehavior('Search')) {
             throw new SwaggerBakeRunTimeException(sprintf(
                 'Search behavior must be loaded on %s',
-                $table::class
+                $table::class,
             ));
         }
 

--- a/src/Lib/MediaType/MediaTypeTrait.php
+++ b/src/Lib/MediaType/MediaTypeTrait.php
@@ -19,8 +19,8 @@ trait MediaTypeTrait
                 sprintf(
                     'Argument must be array or object but was given schemaType `%s`. If you\'re using the ' .
                     'SwagResponseSchema annotation, try defining schemaType.',
-                    $schemaType
-                )
+                    $schemaType,
+                ),
             );
         }
     }

--- a/src/Lib/Model/ModelDecorator.php
+++ b/src/Lib/Model/ModelDecorator.php
@@ -14,7 +14,7 @@ class ModelDecorator
      */
     public function __construct(
         private Model $model,
-        private ?Controller $controller = null
+        private ?Controller $controller = null,
     ) {
     }
 

--- a/src/Lib/Model/ModelScanner.php
+++ b/src/Lib/Model/ModelScanner.php
@@ -33,7 +33,7 @@ class ModelScanner
      */
     public function __construct(
         private readonly RouteScanner $routeScanner,
-        private readonly Configuration $config
+        private readonly Configuration $config,
     ) {
     }
 
@@ -101,7 +101,7 @@ class ModelScanner
         $result = (new Collection($routes))->filter(
             function (RouteDecorator $routeDecorator) use ($model) {
                 return $this->routeHasModel($routeDecorator, $model);
-            }
+            },
         );
 
         return $result->first();

--- a/src/Lib/OpenApi/Content.php
+++ b/src/Lib/OpenApi/Content.php
@@ -20,7 +20,7 @@ class Content implements JsonSerializable
      */
     public function __construct(
         private string $mimeType,
-        private Schema|string $schema
+        private Schema|string $schema,
     ) {
     }
 

--- a/src/Lib/OpenApi/Operation.php
+++ b/src/Lib/OpenApi/Operation.php
@@ -44,7 +44,7 @@ class Operation implements JsonSerializable
         private array $responses = [],
         private array $security = [],
         private bool $isDeprecated = false,
-        private int $sortOrder = 100
+        private int $sortOrder = 100,
     ) {
         $this->setHttpMethod($httpMethod);
         $this->setParameters($parameters);
@@ -196,7 +196,7 @@ class Operation implements JsonSerializable
     {
         if (!in_array($type, Parameter::IN)) {
             throw new InvalidArgumentException(
-                "Invalid parameter type `$type`, must be one: " . implode(', ', Parameter::IN)
+                "Invalid parameter type `$type`, must be one: " . implode(', ', Parameter::IN),
             );
         }
 

--- a/src/Lib/OpenApi/OperationExternalDoc.php
+++ b/src/Lib/OpenApi/OperationExternalDoc.php
@@ -19,7 +19,7 @@ class OperationExternalDoc implements JsonSerializable
      */
     public function __construct(
         private string $url,
-        private string $description = ''
+        private string $description = '',
     ) {
     }
 

--- a/src/Lib/OpenApi/Parameter.php
+++ b/src/Lib/OpenApi/Parameter.php
@@ -86,7 +86,7 @@ class Parameter implements JsonSerializable
         // reduce JSON clutter if these values are equal to their defaults
         return ArrayUtility::removeValuesMatching(
             $vars,
-            ['deprecated' => false, 'allowEmptyValue' => false, 'explode' => false, 'allowReserved' => false]
+            ['deprecated' => false, 'allowEmptyValue' => false, 'explode' => false, 'allowReserved' => false],
         );
     }
 

--- a/src/Lib/OpenApi/Path.php
+++ b/src/Lib/OpenApi/Path.php
@@ -29,7 +29,7 @@ class Path implements JsonSerializable
         private ?string $ref = null,
         private ?string $summary = null,
         private ?string $description = null,
-        private array $tags = []
+        private array $tags = [],
     ) {
         $this->setOperations($operations);
     }

--- a/src/Lib/OpenApi/PathSecurity.php
+++ b/src/Lib/OpenApi/PathSecurity.php
@@ -21,7 +21,7 @@ class PathSecurity implements JsonSerializable
      */
     public function __construct(
         private string $name = '',
-        private array $scopes = []
+        private array $scopes = [],
     ) {
     }
 

--- a/src/Lib/OpenApi/RequestBody.php
+++ b/src/Lib/OpenApi/RequestBody.php
@@ -23,7 +23,7 @@ class RequestBody implements JsonSerializable
         private ?string $description = null,
         private array $content = [],
         private bool $required = false,
-        private bool $ignoreCakeSchema = false
+        private bool $ignoreCakeSchema = false,
     ) {
     }
 

--- a/src/Lib/OpenApi/Response.php
+++ b/src/Lib/OpenApi/Response.php
@@ -22,7 +22,7 @@ class Response implements JsonSerializable
     public function __construct(
         private string $code,
         private ?string $description = null,
-        private array $content = []
+        private array $content = [],
     ) {
     }
 

--- a/src/Lib/OpenApi/Schema.php
+++ b/src/Lib/OpenApi/Schema.php
@@ -56,7 +56,7 @@ class Schema implements JsonSerializable, SchemaInterface
         private int $visibility = OpenApiSchema::VISIBLE_DEFAULT,
         private ?string $refPath = null,
         private bool $isCustomSchema = false,
-        private mixed $example = null
+        private mixed $example = null,
     ) {
     }
 
@@ -70,7 +70,7 @@ class Schema implements JsonSerializable, SchemaInterface
         // always unset
         $vars = ArrayUtility::removeKeysMatching(
             $vars,
-            ['name','refEntity','isPublic', 'refPath', 'visibility', 'isCustomSchema',]
+            ['name','refEntity','isPublic', 'refPath', 'visibility', 'isCustomSchema',],
         );
 
         // must stay in this order to prevent https://github.com/cnizzardini/cakephp-swagger-bake/issues/30
@@ -83,7 +83,7 @@ class Schema implements JsonSerializable, SchemaInterface
         // remove null or empty properties to avoid swagger.json clutter
         $vars = ArrayUtility::removeEmptyVars(
             $vars,
-            ['title','properties','items','oneOf','anyOf','allOf','not','enum','format','type','xml','required']
+            ['title','properties','items','oneOf','anyOf','allOf','not','enum','format','type','xml','required'],
         );
 
         // remove null properties only

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -86,7 +86,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
          */
         $vars = ArrayUtility::removeKeysMatching(
             $vars,
-            ['name','isRequired','requirePresenceOnCreate','requirePresenceOnUpdate','refEntity', 'isHidden']
+            ['name','isRequired','requirePresenceOnCreate','requirePresenceOnUpdate','refEntity', 'isHidden'],
         );
 
         if (!empty($this->refEntity)) {
@@ -102,7 +102,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
                 'format','title','description','multipleOf','minimum','maximum','minLength','maxLength','pattern',
                 'minItems','maxItems','minProperties','maxProperties','items','enum','default','exclusiveMinimum',
                 'exclusiveMaximum','uniqueItems','nullable','type','oneOf',
-            ]
+            ],
         );
 
         /*
@@ -115,7 +115,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
          */
         $vars = ArrayUtility::removeValuesMatching(
             $vars,
-            ['readOnly' => false, 'writeOnly' => false, 'deprecated' => false, 'nullable' => false]
+            ['readOnly' => false, 'writeOnly' => false, 'deprecated' => false, 'nullable' => false],
         );
 
         if (isset($vars['enum']) && is_array($vars['enum'])) {
@@ -123,7 +123,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
         }
 
         if (isset($vars['items'])) {
-            $vars['items'] = (object) reset($vars['items']);
+            $vars['items'] = (object)reset($vars['items']);
         }
 
         return $vars;

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -122,6 +122,10 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             $vars['enum'] = array_values($vars['enum']);
         }
 
+        if (isset($vars['items'])) {
+            $vars['items'] = (object) reset($vars['items']);
+        }
+
         return $vars;
     }
 

--- a/src/Lib/OpenApi/SchemaTrait.php
+++ b/src/Lib/OpenApi/SchemaTrait.php
@@ -31,7 +31,7 @@ trait SchemaTrait
         if ($type !== null && !in_array($type, OpenApiDataType::TYPES)) {
             throw new InvalidArgumentException(
                 "Schema type of `$type` is invalid. Must be one of: " .
-                implode(',', OpenApiDataType::TYPES)
+                implode(',', OpenApiDataType::TYPES),
             );
         }
 

--- a/src/Lib/OpenApiPathGenerator.php
+++ b/src/Lib/OpenApiPathGenerator.php
@@ -25,7 +25,7 @@ class OpenApiPathGenerator
     public function __construct(
         private Swagger $swagger,
         private RouteScanner $routeScanner,
-        private Configuration $config
+        private Configuration $config,
     ) {
     }
 
@@ -74,7 +74,7 @@ class OpenApiPathGenerator
             }
 
             EventManager::instance()->dispatch(
-                new Event('SwaggerBake.Path.created', $path)
+                new Event('SwaggerBake.Path.created', $path),
             );
 
             if (!empty($path->getOperations())) {

--- a/src/Lib/Operation/DtoParser.php
+++ b/src/Lib/Operation/DtoParser.php
@@ -47,7 +47,7 @@ class DtoParser
         foreach ($this->reflection->getProperties() as $reflectionProperty) {
             $queryParam = (new AttributeFactory(
                 $reflectionProperty,
-                OpenApiQueryParam::class
+                OpenApiQueryParam::class,
             ))->createOneOrNull();
 
             if ($queryParam instanceof OpenApiQueryParam) {
@@ -70,7 +70,7 @@ class DtoParser
         foreach ($this->reflection->getProperties() as $reflectionProperty) {
             $schemaProperty = (new AttributeFactory(
                 $reflectionProperty,
-                OpenApiSchemaProperty::class
+                OpenApiSchemaProperty::class,
             ))->createOneOrNull();
 
             if ($schemaProperty instanceof OpenApiSchemaProperty) {
@@ -102,7 +102,7 @@ class DtoParser
             $attr = $schema->field($name);
             $schemaProperty = new SchemaProperty(
                 name: $name,
-                type: DataTypeConversion::toType($attr['type'])
+                type: DataTypeConversion::toType($attr['type']),
             );
             $schemaProperty = (new SchemaPropertyValidation($validator, $schemaProperty, $name))->withValidations();
             $schemaProperties[$name] = $schemaProperty;

--- a/src/Lib/Operation/OperationDocBlock.php
+++ b/src/Lib/Operation/OperationDocBlock.php
@@ -24,7 +24,7 @@ class OperationDocBlock
     public function __construct(
         private Configuration $config,
         private Operation $operation,
-        private DocBlock $doc
+        private DocBlock $doc,
     ) {
     }
 

--- a/src/Lib/Operation/OperationFromRouteFactory.php
+++ b/src/Lib/Operation/OperationFromRouteFactory.php
@@ -87,7 +87,7 @@ class OperationFromRouteFactory
         $operation = new Operation(
             operationId: $route->getName() . ':' . strtolower($httpMethod),
             httpMethod: $httpMethod,
-            sortOrder: $sortOrder
+            sortOrder: $sortOrder,
         );
 
         $operation = $this->createOperation($operation, $route, $openApiOperation);
@@ -125,7 +125,7 @@ class OperationFromRouteFactory
                 'reflectionMethod' => $refMethod,
                 'route' => $route,
                 'schema' => $schema,
-            ])
+            ]),
         );
 
         return $operation;
@@ -166,7 +166,7 @@ class OperationFromRouteFactory
     private function createOperation(
         Operation $operation,
         RouteDecorator $route,
-        ?OpenApiOperation $openApiOperation
+        ?OpenApiOperation $openApiOperation,
     ): Operation {
         if ($openApiOperation instanceof OpenApiOperation) {
             $operation->setSummary($openApiOperation->summary);
@@ -178,7 +178,7 @@ class OperationFromRouteFactory
                     new OperationExternalDoc(
                         $openApiOperation->externalDocs['url'] ?? '',
                         $openApiOperation->externalDocs['description'] ?? '',
-                    )
+                    ),
                 );
             }
             if (is_numeric($openApiOperation->sortOrder)) {

--- a/src/Lib/Operation/OperationFromYmlFactory.php
+++ b/src/Lib/Operation/OperationFromYmlFactory.php
@@ -27,12 +27,12 @@ class OperationFromYmlFactory
             operationId: $yaml['operationId'],
             httpMethod: $httpMethod,
             tags: $yaml['tags'] ?? [],
-            isDeprecated: $yaml['deprecated'] ?? false
+            isDeprecated: $yaml['deprecated'] ?? false,
         );
 
         if (isset($yaml['externalDocs']['url'])) {
             $operation->setExternalDocs(
-                (new OperationExternalDoc($yaml['externalDocs']['url'], $yaml['externalDocs']['description']))
+                new OperationExternalDoc($yaml['externalDocs']['url'], $yaml['externalDocs']['description']),
             );
         }
 

--- a/src/Lib/Operation/OperationPathParameter.php
+++ b/src/Lib/Operation/OperationPathParameter.php
@@ -28,7 +28,7 @@ class OperationPathParameter
         private Operation $operation,
         private RouteDecorator $route,
         private ?ReflectionMethod $reflectionMethod = null,
-        private ?Schema $schema = null
+        private ?Schema $schema = null,
     ) {
     }
 
@@ -74,8 +74,8 @@ class OperationPathParameter
                     name: $id,
                     description: $description ?? null,
                     required: true,
-                    schema: (new Schema())->setType($type ?? 'string')->setFormat($format ?? '')
-                )
+                    schema: (new Schema())->setType($type ?? 'string')->setFormat($format ?? ''),
+                ),
             );
         }
     }
@@ -95,7 +95,7 @@ class OperationPathParameter
         /** @var array<\SwaggerBake\Lib\Attribute\OpenApiPathParam> $openApiPathParams */
         $openApiPathParams = (new AttributeFactory(
             $this->reflectionMethod,
-            OpenApiPathParam::class
+            OpenApiPathParam::class,
         ))->createMany();
 
         $parameters = $this->operation->getParameters();

--- a/src/Lib/Operation/OperationQueryParameter.php
+++ b/src/Lib/Operation/OperationQueryParameter.php
@@ -165,14 +165,14 @@ class OperationQueryParameter
 
         if (!class_exists($dto->class)) {
             throw new SwaggerBakeRunTimeException(
-                sprintf('DTO class %s not found', $dto->class)
+                sprintf('DTO class %s not found', $dto->class),
             );
         }
 
         // get openapi schema query params defined on the class
         $queryParams = (new AttributeFactory(
             new ReflectionClass($dto->class),
-            OpenApiQueryParam::class
+            OpenApiQueryParam::class,
         ))->createMany();
         /** @var array<\SwaggerBake\Lib\Attribute\OpenApiQueryParam> $queryParams */
         $parameters = array_map(function ($param) {

--- a/src/Lib/Operation/OperationRequestBody.php
+++ b/src/Lib/Operation/OperationRequestBody.php
@@ -37,7 +37,7 @@ class OperationRequestBody
         private Operation $operation,
         private RouteDecorator $route,
         private ?ReflectionMethod $refMethod = null,
-        private ?Schema $schema = null
+        private ?Schema $schema = null,
     ) {
         $this->config = $swagger->getConfig();
     }
@@ -73,7 +73,7 @@ class OperationRequestBody
     {
         $openApiRequestBody = (new AttributeFactory(
             $this->refMethod,
-            OpenApiRequestBody::class
+            OpenApiRequestBody::class,
         ))->createOneOrNull();
 
         if (!$openApiRequestBody instanceof OpenApiRequestBody) {
@@ -91,7 +91,7 @@ class OperationRequestBody
             $pieces = explode('/', $openApiRequestBody->ref);
             $entity = end($pieces);
             $schema = $this->getSchemaWithRequiredProperties(
-                $this->swagger->getSchemaByName($entity)
+                $this->swagger->getSchemaByName($entity),
             );
         }
 
@@ -100,7 +100,7 @@ class OperationRequestBody
         }
 
         $this->operation->setRequestBody(
-            $openApiRequestBody->createRequestBody($requestBody)
+            $openApiRequestBody->createRequestBody($requestBody),
         );
     }
 
@@ -115,7 +115,7 @@ class OperationRequestBody
         /** @var array<\SwaggerBake\Lib\Attribute\OpenApiForm> $openApiForms */
         $openApiForms = (new AttributeFactory(
             $this->refMethod,
-            OpenApiForm::class
+            OpenApiForm::class,
         ))->createMany();
 
         if (empty($openApiForms)) {
@@ -126,7 +126,7 @@ class OperationRequestBody
 
         foreach ($openApiForms as $attribute) {
             $schema->pushProperty(
-                $attribute->create()
+                $attribute->create(),
             );
         }
 
@@ -149,7 +149,7 @@ class OperationRequestBody
     {
         $openApiDto = (new AttributeFactory(
             $this->refMethod,
-            OpenApiDto::class
+            OpenApiDto::class,
         ))->createOneOrNull();
 
         if (!$openApiDto instanceof OpenApiDto || !class_exists($openApiDto->class)) {
@@ -160,7 +160,7 @@ class OperationRequestBody
         $dtoReflection = new ReflectionClass($openApiDto->class);
         $openApiSchema = (new AttributeFactory(
             $dtoReflection,
-            OpenApiSchema::class
+            OpenApiSchema::class,
         ))->createOneOrNull();
 
         // add schema to #/components/schemas ?
@@ -178,7 +178,7 @@ class OperationRequestBody
         // get openapi schema properties defined on the class
         $schemaProperties = (new AttributeFactory(
             $dtoReflection,
-            OpenApiSchemaProperty::class
+            OpenApiSchemaProperty::class,
         ))->createMany();
         /** @var array<\SwaggerBake\Lib\Attribute\OpenApiSchemaProperty> $schemaProperties */
         $properties = array_map(function ($prop) {
@@ -215,7 +215,7 @@ class OperationRequestBody
         if ($this->refMethod instanceof ReflectionMethod) {
             $openApiRequestBody = (new AttributeFactory(
                 $this->refMethod,
-                OpenApiRequestBody::class
+                OpenApiRequestBody::class,
             ))->createOneOrNull();
         }
 

--- a/src/Lib/Operation/OperationResponse.php
+++ b/src/Lib/Operation/OperationResponse.php
@@ -46,7 +46,7 @@ class OperationResponse
         private Operation $operation,
         private RouteDecorator $route,
         private ?Schema $schema = null,
-        private ?ReflectionMethod $refMethod = null
+        private ?ReflectionMethod $refMethod = null,
     ) {
     }
 
@@ -152,7 +152,7 @@ class OperationResponse
             /** @var \SwaggerBake\Lib\Attribute\OpenApiSchema|null $openApiSchema */
             $openApiSchema = (new AttributeFactory(
                 $reflection,
-                OpenApiSchema::class
+                OpenApiSchema::class,
             ))->createOneOrNull();
 
             $schema = $this->createResponseSchema($reflection, $openApiResponse, $openApiSchema);
@@ -160,7 +160,7 @@ class OperationResponse
             // class level attributes
             $schemaProperties = (new AttributeFactory(
                 $reflection,
-                OpenApiSchemaProperty::class
+                OpenApiSchemaProperty::class,
             ))->createMany();
             foreach ($schemaProperties as $schemaProperty) {
                 $schema->pushProperty($schemaProperty->create());
@@ -170,7 +170,7 @@ class OperationResponse
             foreach ($reflection->getProperties() as $reflectionProperty) {
                 $schemaProperty = (new AttributeFactory(
                     $reflectionProperty,
-                    OpenApiSchemaProperty::class
+                    OpenApiSchemaProperty::class,
                 ))->createOneOrNull();
 
                 if ($schemaProperty instanceof OpenApiSchemaProperty) {
@@ -211,7 +211,7 @@ class OperationResponse
     private function createResponseSchema(
         ReflectionClass $reflectionClass,
         OpenApiResponse $openApiResponse,
-        ?OpenApiSchema $openApiSchema
+        ?OpenApiSchema $openApiSchema,
     ): Schema {
         // create base schema from implementation
         if ($reflectionClass->implementsInterface(CustomSchemaInterface::class)) {
@@ -283,11 +283,11 @@ class OperationResponse
             $schema = $this->getMimeTypeSchema(
                 $mimeType,
                 $openApiResponse->schemaType,
-                $assocSchema
+                $assocSchema,
             );
             $response->pushContent(new Content(
                 $mimeType,
-                $openApiResponse->schemaFormat ? $schema->setFormat($openApiResponse->schemaFormat) : $schema
+                $openApiResponse->schemaFormat ? $schema->setFormat($openApiResponse->schemaFormat) : $schema,
             ));
             $this->operation->pushResponse($response);
 

--- a/src/Lib/Operation/OperationResponseAssociation.php
+++ b/src/Lib/Operation/OperationResponseAssociation.php
@@ -42,7 +42,7 @@ class OperationResponseAssociation
         private readonly RouteDecorator $route,
         private readonly ?Schema $schema = null,
         private ?LocatorInterface $locator = null,
-        private ?Inflector $inflector = null
+        private ?Inflector $inflector = null,
     ) {
         $this->locator = $locator ?? TableRegistry::getTableLocator();
         $this->inflector = $inflector ?? new Inflector();
@@ -109,7 +109,7 @@ class OperationResponseAssociation
         Table $table,
         Schema $schema,
         array $assoc,
-        ?array $current = null
+        ?array $current = null,
     ): Schema {
         $current = $current ?? array_slice($assoc, 0, 1);
         try {
@@ -119,8 +119,8 @@ class OperationResponseAssociation
                 sprintf(
                     'OpenApiResponse association not found. Declared on %s result in error: %s',
                     $this->route->getControllerFqn() . '::' . $this->route->getAction(),
-                    $e->getMessage()
-                )
+                    $e->getMessage(),
+                ),
             );
         }
 

--- a/src/Lib/Operation/OperationSecurity.php
+++ b/src/Lib/Operation/OperationSecurity.php
@@ -22,7 +22,7 @@ class OperationSecurity
      */
     public function __construct(
         private Operation $operation,
-        private ?ReflectionMethod $refMethod
+        private ?ReflectionMethod $refMethod,
     ) {
     }
 
@@ -60,7 +60,7 @@ class OperationSecurity
             $this->operation->pushSecurity(
                 (new PathSecurity())
                     ->setName($sec->name)
-                    ->setScopes($sec->scopes)
+                    ->setScopes($sec->scopes),
             );
         }
     }

--- a/src/Lib/Route/RouteDecorator.php
+++ b/src/Lib/Route/RouteDecorator.php
@@ -315,7 +315,7 @@ class RouteDecorator
 
                 return $piece;
             },
-            explode('/', $this->template)
+            explode('/', $this->template),
         );
 
         return implode('/', $pieces);

--- a/src/Lib/Schema/SchemaFactory.php
+++ b/src/Lib/Schema/SchemaFactory.php
@@ -69,7 +69,7 @@ class SchemaFactory
         EventManager::instance()->dispatch(
             new Event('SwaggerBake.Schema.created', $schema, [
                 'modelDecorator' => $modelDecorator,
-            ])
+            ]),
         );
 
         return $schema;
@@ -204,7 +204,7 @@ class SchemaFactory
         /** @var array<\SwaggerBake\Lib\Attribute\OpenApiSchemaProperty> $attributes */
         $attributes = (new AttributeFactory(
             new ReflectionClass($model->getEntity()),
-            OpenApiSchemaProperty::class
+            OpenApiSchemaProperty::class,
         ))->createMany();
 
         $return = [];

--- a/src/Lib/Schema/SchemaFromYamlFactory.php
+++ b/src/Lib/Schema/SchemaFromYamlFactory.php
@@ -41,7 +41,7 @@ class SchemaFromYamlFactory
                     ->setAttribute($yml['xml']['attribute'] ?? null)
                     ->setNamespace($yml['xml']['namespace'] ?? null)
                     ->setPrefix($yml['xml']['prefix'] ?? null)
-                    ->setWrapped($yml['xml']['wrapped'] ?? null)
+                    ->setWrapped($yml['xml']['wrapped'] ?? null),
             );
         }
 
@@ -54,14 +54,14 @@ class SchemaFromYamlFactory
              */
             if (!empty($propertyVar['type']) && $propertyVar['type'] === 'object') {
                 $schema->pushProperty(
-                    $this->create($propertyName, $propertyVar)
+                    $this->create($propertyName, $propertyVar),
                 );
             /*
              * Property is a property
              */
             } else {
                 $schema->pushProperty(
-                    $factory->create($propertyName, $propertyVar)
+                    $factory->create($propertyName, $propertyVar),
                 );
             }
         }

--- a/src/Lib/Schema/SchemaPropertyFactory.php
+++ b/src/Lib/Schema/SchemaPropertyFactory.php
@@ -24,7 +24,7 @@ class SchemaPropertyFactory
      */
     public function __construct(
         private Validator $validator,
-        private ?DocBlock $docBlock = null
+        private ?DocBlock $docBlock = null,
     ) {
     }
 
@@ -94,7 +94,7 @@ class SchemaPropertyFactory
             function ($tag) use ($property) {
                 /** @var \phpDocumentor\Reflection\DocBlock\Tags\Property $tag */
                 return $tag->getVariableName() === $property->getName();
-            }
+            },
         );
 
         return !empty($results) ? reset($results) : null;

--- a/src/Lib/Schema/SchemaPropertyFormat.php
+++ b/src/Lib/Schema/SchemaPropertyFormat.php
@@ -43,7 +43,7 @@ class SchemaPropertyFormat
     public function __construct(
         private Validator $validator,
         private SchemaProperty $schemaProperty,
-        ModelProperty $property
+        ModelProperty $property,
     ) {
         $this->propertyName = $property->getName();
     }

--- a/src/Lib/Schema/SchemaPropertyValidation.php
+++ b/src/Lib/Schema/SchemaPropertyValidation.php
@@ -27,7 +27,7 @@ class SchemaPropertyValidation
     public function __construct(
         private Validator $validator,
         private SchemaProperty $schemaProperty,
-        ModelProperty|string $property
+        ModelProperty|string $property,
     ) {
         $this->propertyName = is_string($property) ? $property : $property->getName();
     }

--- a/src/Lib/Service/InstallerService.php
+++ b/src/Lib/Service/InstallerService.php
@@ -17,7 +17,7 @@ class InstallerService
      */
     public function __construct(
         private string $configDir = CONFIG,
-        ?FileUtility $fileUtility = null
+        ?FileUtility $fileUtility = null,
     ) {
         $this->fileUtility = $fileUtility ?? new FileUtility();
     }
@@ -37,7 +37,7 @@ class InstallerService
         $swaggerYml = $this->configDir . 'swagger.yml';
         if (!$this->fileUtility->copy($fromAssets, $swaggerYml)) {
             throw new InstallException(
-                "Error copying base OpenAPI YAML from `$fromAssets` to `$swaggerYml`"
+                "Error copying base OpenAPI YAML from `$fromAssets` to `$swaggerYml`",
             );
         }
 
@@ -45,7 +45,7 @@ class InstallerService
         $swaggerBake = $this->configDir . 'swagger_bake.php';
         if (!$this->fileUtility->copy($fromAssets, $swaggerBake)) {
             throw new InstallException(
-                "Error copying swagger_bake config from `$fromAssets` to `$swaggerBake`"
+                "Error copying swagger_bake config from `$fromAssets` to `$swaggerBake`",
             );
         }
 
@@ -82,7 +82,7 @@ class InstallerService
     {
         if (!str_starts_with($prefix, '/') || !filter_var('http://localhost' . $prefix, FILTER_VALIDATE_URL)) {
             throw new InstallException(
-                "Prefix is invalid. Prefix `$prefix` should start with a `/` and be a valid URL path."
+                "Prefix is invalid. Prefix `$prefix` should start with a `/` and be a valid URL path.",
             );
         }
 
@@ -90,8 +90,8 @@ class InstallerService
             throw new InstallException(
                 sprintf(
                     'Assets directory `%s` does not exist. Please correct the issue or install manually.',
-                    self::ASSETS
-                )
+                    self::ASSETS,
+                ),
             );
         }
 
@@ -101,7 +101,7 @@ class InstallerService
             throw (new InstallException())
                 ->setQuestion(
                     'The installer found an existing swagger.yml and/or swagger_bake.php file. ' .
-                    'Do you want to continue & overwrite these files?'
+                    'Do you want to continue & overwrite these files?',
                 );
         }
     }

--- a/src/Lib/Swagger.php
+++ b/src/Lib/Swagger.php
@@ -44,7 +44,7 @@ class Swagger
     public function __construct(
         private ModelScanner $modelScanner,
         private Configuration $config,
-        private ?FileUtility $fileUtility = null
+        private ?FileUtility $fileUtility = null,
     ) {
         $this->fileUtility = $fileUtility ?? new FileUtility();
     }
@@ -63,11 +63,11 @@ class Swagger
 
         $this->array['x-swagger-bake'] = array_merge_recursive(
             $xSwaggerBake['x-swagger-bake'],
-            $this->array['x-swagger-bake'] ?? []
+            $this->array['x-swagger-bake'] ?? [],
         );
 
         EventManager::instance()->dispatch(
-            new Event('SwaggerBake.initialize', $this)
+            new Event('SwaggerBake.initialize', $this),
         );
 
         $this->array = (new OpenApiSchemaGenerator($this->modelScanner))->generate($this->array);
@@ -104,7 +104,7 @@ class Swagger
             uksort($this->array['components']['schemas'], function ($a, $b) {
                 return strcasecmp(
                     preg_replace('/\s+/', '', $a),
-                    preg_replace('/\s+/', '', $b)
+                    preg_replace('/\s+/', '', $b),
                 );
             });
         }
@@ -140,7 +140,7 @@ class Swagger
         $this->addAdditionalSchema();
 
         EventManager::instance()->dispatch(
-            new Event('SwaggerBake.beforeRender', $this)
+            new Event('SwaggerBake.beforeRender', $this),
         );
 
         $json = json_encode($this->getArray(), $this->config->getJsonOptions());
@@ -211,7 +211,7 @@ class Swagger
                 $operations,
                 array_filter($path->getOperations(), function ($operation) {
                     return !$operation->hasSuccessResponseCode();
-                })
+                }),
             );
         }
 
@@ -283,7 +283,7 @@ class Swagger
                         ->setType('array')
                         ->setItems([
                             '$ref' => $schema->getRefPath(),
-                        ])
+                        ]),
                 );
             } else {
                 $content->setSchema($schema->getRefPath());

--- a/src/Lib/SwaggerFactory.php
+++ b/src/Lib/SwaggerFactory.php
@@ -22,7 +22,7 @@ class SwaggerFactory
      */
     public function __construct(
         private ?Configuration $config = null,
-        private ?RouteScanner $routeScanner = null
+        private ?RouteScanner $routeScanner = null,
     ) {
         $this->config = $config ?? new Configuration();
 

--- a/src/Lib/Utility/NamespaceUtility.php
+++ b/src/Lib/Utility/NamespaceUtility.php
@@ -84,7 +84,7 @@ class NamespaceUtility
 
             $classes = array_merge(
                 $classes,
-                MixerApiNsUtil::findClasses($namespace)
+                MixerApiNsUtil::findClasses($namespace),
             );
         }
 


### PR DESCRIPTION
Fixes custom array schema's resulting in output like this in swagger:

```json
{
  "array_property": [
    "string"
  ]
}
```

Now supports defining custom array like this:

```php
(new SchemaProperty('foo_schemas', 'array'))->setItems([
    [
        'type' => 'object',
        'allOf' => [['$ref' => '#/components/schemas/FooSchema']]
    ]
]),
```

outputting...

```json
"foo_schemas": [
  {
    "id": 0,
    "name": "string",
  }
],
```
