### PR TITLE
Fix custom array schema

### DIFF
--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -122,6 +122,10 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             $vars['enum'] = array_values($vars['enum']);
         }
 
+        if (isset($vars['items'])) {
+            $vars['items'] = (object)reset($vars['items']);
+        }
+
         return $vars;
     }
 

--- a/src/Lib/OpenApi/SchemaProperty.php
+++ b/src/Lib/OpenApi/SchemaProperty.php
@@ -122,7 +122,7 @@ class SchemaProperty implements JsonSerializable, SchemaInterface
             $vars['enum'] = array_values($vars['enum']);
         }
 
-        if (isset($vars['items'])) {
+        if (!empty($vars['items'])) {
             $vars['items'] = (object)reset($vars['items']);
         }
 


### PR DESCRIPTION
Fixes custom array schema's resulting in output like this in swagger:

```json
{
  "array_property": [
    "string"
  ]
}
```

Now supports defining custom array like this:

```php
(new SchemaProperty('foo_schemas', 'array'))->setItems([
    [
        'type' => 'object',
        'allOf' => [['$ref' => '#/components/schemas/FooSchema']]
    ]
]),
```

outputting...

```json
"foo_schemas": [
  {
    "id": 0,
    "name": "string",
  }
],
```
