### PR TITLE
use updated routing from core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "cakephp/cakephp": "^5.0",
         "symfony/yaml": "^5.0",
         "phpdocumentor/reflection-docblock": "^5.1",
-        "mixerapi/core": "^2.0"
+        "mixerapi/core": "master-dev"
     },
     "suggest": {
         "cakephp/bake": "Used by SwaggerBake bake templates",
@@ -79,5 +79,11 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/MasaKni/core.git"
+        }
+    ]
 }

--- a/tests/test_app/src/Controller/OperationPathController.php
+++ b/tests/test_app/src/Controller/OperationPathController.php
@@ -8,7 +8,7 @@ use SwaggerBake\Lib\Attribute\OpenApiPathParam;
 class OperationPathController extends AppController
 {
     #[OpenApiPathParam(name: 'id', type: 'integer', format: 'int64', description: 'ID')]
-    public function pathParameter(string $id = null): void
+    public function pathParameter(?string $id = null): void
     {
 
     }


### PR DESCRIPTION
update mixerapi/core for using the library with PHP 8.4 and fix deprecations.