### PR TITLE
Handle cakephp 5.3 deprecations

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    name: PHP 8.4 Test / Analysis
+    name: PHP 8.5 Test / Analysis
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, intl, xdebug
 
       - name: PHP Version

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['~5.0.0', '^5.3']
+        version: ['~5.0.0', '^5.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['~5.0.0', '^5.0']
+        version: ['~5.0.0', '^5.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -42,7 +42,6 @@
     <rule ref="rulesets/unusedcode.xml">
         <exclude name="UnusedPrivateField"/>
     </rule>
-    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod" />
     <rule ref="rulesets/controversial.xml/CamelCaseParameterName" />
     <rule ref="rulesets/controversial.xml/CamelCaseMethodName" />
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity">

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -39,7 +39,9 @@
         </properties>
     </rule>
     <rule ref="rulesets/naming.xml/ShortMethodName" />
-    <rule ref="rulesets/unusedcode.xml/UnusedPrivateField" />
+    <rule ref="rulesets/unusedcode.xml">
+        <exclude name="UnusedPrivateField"/>
+    </rule>
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod" />
     <rule ref="rulesets/controversial.xml/CamelCaseParameterName" />
     <rule ref="rulesets/controversial.xml/CamelCaseMethodName" />

--- a/src/Lib/Extension/CakeSearch/Extension.php
+++ b/src/Lib/Extension/CakeSearch/Extension.php
@@ -43,7 +43,7 @@ class Extension implements ExtensionInterface
     {
         EventManager::instance()
             ->on('SwaggerBake.Operation.created', function (Event $event): void {
-                $operation = $this->getOperation($event); // phpcs:ignore
+                $this->getOperation($event);
             });
     }
 

--- a/src/Lib/Operation/ExceptionResponse.php
+++ b/src/Lib/Operation/ExceptionResponse.php
@@ -87,17 +87,15 @@ class ExceptionResponse
 
         $this->code = empty($httpCode) ? '500' : $httpCode;
         $this->description = $description;
-        $this->schema = $this->fallback($exceptionFqn);
+        $this->schema = $this->fallback();
 
         return $this;
     }
 
     /**
      * @deprecated this method may be removed in version 3.
-     * @param string $exceptionFqn The FQN of the exception class.
-     * @return string|null
      */
-    private function fallback(string $exceptionFqn): ?string
+    private function fallback(): ?string
     {
         if (empty($this->config->getExceptionSchema())) {
             return null;

--- a/src/SwaggerBakePlugin.php
+++ b/src/SwaggerBakePlugin.php
@@ -13,7 +13,7 @@ use SwaggerBake\Lib\Service\InstallerService;
 use SwaggerBake\Lib\Service\OpenApiBakerService;
 use SwaggerBake\Lib\Service\OpenApiControllerService;
 
-class Plugin extends BasePlugin
+class SwaggerBakePlugin extends BasePlugin
 {
     protected bool $routes = false;
 

--- a/tests/test_app/src/Model/Table/EmployeesTable.php
+++ b/tests/test_app/src/Model/Table/EmployeesTable.php
@@ -28,7 +28,7 @@ class EmployeesTable extends Table
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');
         $this->addBehavior('Search.Search');
-        $this->searchManager()
+        $this->getBehavior('Search')->searchManager()
             ->add('first_name', 'Search.Like', [
                 'before' => true,
                 'after' => true,


### PR DESCRIPTION
This PR updates SwaggerBake to address CakePHP 5.3 deprecations by adjusting plugin/bootstrap conventions and replacing deprecated API usage in test and extension code.

**Changes:**
- Update FriendsOfCake/Search usage to call `searchManager()` via the Search behavior instance.
- Rename the plugin entry class to `SwaggerBakePlugin` and simplify an event listener to avoid an unused variable.
- Update deprecated `ExceptionResponse::fallback()` signature and adjust PHPMD configuration.
